### PR TITLE
add tag-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: build-${{ matrix.asset }}
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            asset: fuori-linux-x64.tar.gz
+          - runner: macos-15-intel
+            asset: fuori-macos-x64.tar.gz
+          - runner: macos-latest
+            asset: fuori-macos-arm64.tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: make
+
+      - name: Package
+        run: tar -czf "${{ matrix.asset }}" fuori
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+
+  release:
+    name: publish-release
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: dist
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --title "$tag" --generate-notes
+          gh release upload "$tag" dist/*/* --clobber


### PR DESCRIPTION
This adds a GitHub Actions release workflow for tagged versions.

The workflow triggers on version tags matching v*, builds release binaries for linux-x64, macos-x64, and macos-arm64, packages each build as a .tar.gz, uploads them as workflow artifacts, and then creates or updates the corresponding GitHub Release with those assets attached.

This keeps release creation lightweight and repeatable while matching the current scope of the project: a small C binary with no external dependencies. The first version intentionally stays minimal and avoids extra packaging or signing steps until the release flow is proven.