### PR TITLE
Add token estimate summary and configurable budget thresholds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 CC = gcc
+CPPFLAGS += -DVERSION=\"$(VERSION)\"
 CFLAGS = -Wall -Wextra -Wshadow -Wcast-align -Wwrite-strings -Wredundant-decls \
          -Wstrict-prototypes -Wold-style-definition -std=c99 -O2 -D_POSIX_C_SOURCE=200809L
 TARGET = fuori
 SOURCES = main.c collect.c render.c git_paths.c ignore.c
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
+VERSION ?= dev
 
 all: $(TARGET)
 
 $(TARGET): $(SOURCES)
-	$(CC) $(CFLAGS) -o $(TARGET) $(SOURCES)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $(TARGET) $(SOURCES)
 
 clean:
 	rm -f $(TARGET)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ By default, the application creates a file named `_export.md` in the current dir
 ```
 
 **Options:**
+- `-V, --version`: Show version information
 - `-v, --verbose`: Show progress information during processing
 - `-s <size_kb>`: Set maximum file size limit in KB (default: 100)
 - `-o, --output <path>`: Set output path (use `-` for stdout)
@@ -82,6 +83,9 @@ Git file-selection modes are mutually exclusive: use at most one of `--staged`, 
 ```bash
 # Basic usage
 fuori
+
+# Show version
+fuori --version
 
 # With verbose output
 fuori -v

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A C application that exports a codebase to a single Markdown file with UTF-8 enc
 - Automatically detects and excludes binary files
 - Excludes files larger than 100KB (configurable)
 - Formats code in Markdown with appropriate language identifiers
+- Estimates final artifact token usage with a conservative 3.5 chars/token heuristic
 - Outputs to `_export.md` by default (configurable, including stdout)
 - Simple C implementation that is easy to inspect and review
 - Zero dependencies, plain C99 + POSIX, compiles in seconds on almost anything
@@ -70,6 +71,8 @@ By default, the application creates a file named `_export.md` in the current dir
 - `--tree`: Include the project tree section (default)
 - `--no-tree`: Omit the project tree section
 - `--tree-depth <n>` / `--tree-depth=<n>`: Limit tree rendering depth to `n` levels
+- `--warn-tokens <n>` / `--warn-tokens=<n>`: Warn if the estimated token count exceeds `n` (default: 200000)
+- `--max-tokens <n>` / `--max-tokens=<n>`: Fail before writing output if the estimated token count exceeds `n`
 - `--no-clobber`: Fail if output file already exists
 - `-h, --help`: Display help message
 
@@ -112,6 +115,12 @@ fuori --diff HEAD~3..HEAD
 
 # Export files changed on the current branch since it diverged from main
 fuori --diff main...HEAD
+
+# Warn earlier for smaller context windows
+fuori --warn-tokens 100000
+
+# Refuse to write exports above a hard token budget
+fuori --max-tokens 180000
 
 # Show help
 fuori --help
@@ -157,6 +166,26 @@ Additional semantics:
 - Renamed files are exported under the current path reported by Git
 - If Git selects no files, `fuori` still succeeds and writes only the normal export header
 
+## Token Estimates
+
+After a successful export, `fuori` prints a compact summary to `stderr`:
+
+```text
+Files exported: 42
+Bytes written:  183,421
+Est. tokens:    ~52,400  (approx, assuming BPE ~3.5 chars/token)
+```
+
+The estimate is based on the final Markdown artifact, not just the raw source files, so headings, code fences, and the optional tree section are included in the byte count before estimating tokens.
+
+By default, `fuori` warns when the estimate exceeds 200,000 tokens:
+
+```text
+Warning: output may exceed 200,000 token context window. Consider using --staged or --diff to narrow scope.
+```
+
+Use `--warn-tokens <n>` to change the warning threshold, or `--max-tokens <n>` to fail before writing any output when the estimated size would exceed a hard limit.
+
 ## Binary File Detection
 
 The application automatically detects binary files by analyzing their content and excludes them from the export.
@@ -172,6 +201,7 @@ The output markdown file will contain:
 3. A header with the file path
 4. A code block with the file content
 5. Appropriate language identifiers for syntax highlighting
+6. A `stderr` summary of files, bytes, and estimated tokens after successful completion
 
 Example:
 ````markdown

--- a/app.h
+++ b/app.h
@@ -12,6 +12,7 @@
 #define MAX_PATH_LENGTH PATH_MAX
 #define IGNORE_FILE ".gitignore"
 #define DEFAULT_OUTPUT_FILE "_export.md"
+#define DEFAULT_WARN_TOKENS 200000
 
 typedef struct {
     int verbose;
@@ -20,6 +21,8 @@ typedef struct {
     int show_tree;
     size_t max_file_size;
     size_t tree_depth;
+    size_t warn_tokens;
+    size_t max_tokens;
     const char* output_path;
     char** ignore_patterns;
     size_t ignore_count;

--- a/collect.c
+++ b/collect.c
@@ -710,6 +710,7 @@ int collect_selected_export_plan(const SelectedPath* selected_paths,
             continue;
         }
 
+        /* Symlinks are skipped inside collect_exportable_file via the S_ISREG guard above. */
         if (collect_exportable_file(path->open_path, path->display_path, &st, ctx, 0, 0, plan) != 0) {
             return -1;
         }

--- a/main.c
+++ b/main.c
@@ -13,6 +13,10 @@
 #include "ignore.h"
 #include "render.h"
 
+#ifndef VERSION
+#define VERSION "dev"
+#endif
+
 static int parse_positive_size_value(const char* value,
                                      const char* label,
                                      size_t max_value,
@@ -42,6 +46,7 @@ static void print_usage(const char* argv0) {
     printf("Usage: %s [OPTIONS]\n", argv0);
     printf("Export codebase to markdown file.\n\n");
     printf("Options:\n");
+    printf("  -V, --version       Show version information\n");
     printf("  -v, --verbose       Show progress information\n");
     printf("  -s <size_kb>        Set maximum file size limit in KB (default: 100)\n");
     printf("  -o, --output        Set output path (use '-' for stdout)\n");
@@ -173,7 +178,10 @@ int main(int argc, char* argv[]) {
     temp_output_path[0] = '\0';
 
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
+        if (strcmp(argv[i], "-V") == 0 || strcmp(argv[i], "--version") == 0) {
+            printf("fuori %s\n", VERSION);
+            return 0;
+        } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
             ctx.verbose = 1;
         } else if (strcmp(argv[i], "-s") == 0) {
             if (i + 1 < argc) {

--- a/main.c
+++ b/main.c
@@ -13,6 +13,110 @@
 #include "ignore.h"
 #include "render.h"
 
+static int parse_positive_size_value(const char* value,
+                                     const char* label,
+                                     size_t max_value,
+                                     size_t* out) {
+    char* endptr;
+    unsigned long long parsed;
+
+    if (!value || !out) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    errno = 0;
+    parsed = strtoull(value, &endptr, 10);
+    if (*value == '\0' || *endptr != '\0' || parsed == 0 ||
+        errno == ERANGE || parsed > max_value) {
+        fprintf(stderr, "Invalid %s value: %s\n", label, value);
+        fprintf(stderr, "Use -h or --help for usage information\n");
+        return -1;
+    }
+
+    *out = (size_t)parsed;
+    return 0;
+}
+
+static void print_usage(const char* argv0) {
+    printf("Usage: %s [OPTIONS]\n", argv0);
+    printf("Export codebase to markdown file.\n\n");
+    printf("Options:\n");
+    printf("  -v, --verbose       Show progress information\n");
+    printf("  -s <size_kb>        Set maximum file size limit in KB (default: 100)\n");
+    printf("  -o, --output        Set output path (use '-' for stdout)\n");
+    printf("      --staged        Export staged files from the current Git subtree\n");
+    printf("      --unstaged      Export unstaged tracked files from the current Git subtree\n");
+    printf("      --diff <r>      Export files changed by a git diff range (for example main...HEAD)\n");
+    printf("                      Git file-selection flags are mutually exclusive\n");
+    printf("      --tree          Include a directory tree section (default)\n");
+    printf("      --no-tree       Omit the directory tree section\n");
+    printf("      --tree-depth    Limit tree rendering depth to N levels\n");
+    printf("      --warn-tokens   Warn if estimated tokens exceed N (default: %d)\n",
+           DEFAULT_WARN_TOKENS);
+    printf("      --max-tokens    Fail if estimated tokens exceed N\n");
+    printf("      --no-clobber    Fail if output file already exists\n");
+    printf("  -h, --help          Show this help message\n");
+}
+
+static int format_size_with_commas(size_t value, char* buffer, size_t buffer_size) {
+    char reversed[64];
+    size_t digits = 0;
+    size_t used = 0;
+
+    if (!buffer || buffer_size == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    do {
+        if (digits >= sizeof(reversed) - 1) {
+            errno = EOVERFLOW;
+            return -1;
+        }
+        if (digits > 0 && digits % 3 == 0) {
+            reversed[digits++] = ',';
+        }
+        reversed[digits++] = (char)('0' + (value % 10));
+        value /= 10;
+    } while (value > 0);
+
+    if (digits + 1 > buffer_size) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    while (digits > 0) {
+        buffer[used++] = reversed[--digits];
+    }
+    buffer[used] = '\0';
+    return 0;
+}
+
+static void print_export_summary(const ExportMetrics* metrics) {
+    char files_buf[32];
+    char bytes_buf[32];
+    char tokens_buf[32];
+
+    if (!metrics) {
+        return;
+    }
+
+    if (format_size_with_commas(metrics->files_exported, files_buf, sizeof(files_buf)) != 0 ||
+        format_size_with_commas(metrics->bytes_written, bytes_buf, sizeof(bytes_buf)) != 0 ||
+        format_size_with_commas(metrics->estimated_tokens, tokens_buf, sizeof(tokens_buf)) != 0) {
+        fprintf(stderr, "Files exported: %zu\n", metrics->files_exported);
+        fprintf(stderr, "Bytes written:  %zu\n", metrics->bytes_written);
+        fprintf(stderr, "Est. tokens:    ~%zu  (approx, assuming BPE ~3.5 chars/token)\n",
+                metrics->estimated_tokens);
+        return;
+    }
+
+    fprintf(stderr, "Files exported: %s\n", files_buf);
+    fprintf(stderr, "Bytes written:  %s\n", bytes_buf);
+    fprintf(stderr, "Est. tokens:    ~%s  (approx, assuming BPE ~3.5 chars/token)\n", tokens_buf);
+}
+
 static int make_temp_output_template(const char* output_path, char* tmpl, size_t tmpl_size) {
     char path_copy[MAX_PATH_LENGTH];
     if (!output_path || !tmpl || tmpl_size == 0) {
@@ -54,6 +158,7 @@ int main(int argc, char* argv[]) {
     SelectedPath* selected_paths = NULL;
     size_t selected_count = 0;
     ExportPlan plan = {0};
+    ExportMetrics metrics = {0};
     int status = 1;
     int temp_created = 0;
     int output_needs_close = 0;
@@ -63,6 +168,7 @@ int main(int argc, char* argv[]) {
     ctx.max_file_size = MAX_FILE_SIZE;
     ctx.show_tree = 1;
     ctx.tree_depth = SIZE_MAX;
+    ctx.warn_tokens = DEFAULT_WARN_TOKENS;
     ctx.output_path = DEFAULT_OUTPUT_FILE;
     temp_output_path[0] = '\0';
 
@@ -71,17 +177,11 @@ int main(int argc, char* argv[]) {
             ctx.verbose = 1;
         } else if (strcmp(argv[i], "-s") == 0) {
             if (i + 1 < argc) {
-                char* endptr;
-                errno = 0;
-                unsigned long long size_kb = strtoull(argv[++i], &endptr, 10);
-                if (*endptr == '\0' && size_kb > 0 &&
-                    errno != ERANGE && size_kb <= (SIZE_MAX / 1024ULL)) {
-                    ctx.max_file_size = (size_t)size_kb * 1024ULL;
-                } else {
-                    fprintf(stderr, "Invalid size value: %s\n", argv[i]);
-                    fprintf(stderr, "Use -h or --help for usage information\n");
+                size_t size_kb;
+                if (parse_positive_size_value(argv[++i], "size", SIZE_MAX / 1024ULL, &size_kb) != 0) {
                     return 1;
                 }
+                ctx.max_file_size = size_kb * 1024ULL;
             } else {
                 fprintf(stderr, "Missing size value for -s option\n");
                 fprintf(stderr, "Use -h or --help for usage information\n");
@@ -115,14 +215,7 @@ int main(int argc, char* argv[]) {
             ctx.show_tree = 0;
         } else if (strcmp(argv[i], "--tree-depth") == 0) {
             if (i + 1 < argc) {
-                char* endptr;
-                errno = 0;
-                unsigned long long depth = strtoull(argv[++i], &endptr, 10);
-                if (*endptr == '\0' && depth > 0 && errno != ERANGE && depth <= SIZE_MAX) {
-                    ctx.tree_depth = (size_t)depth;
-                } else {
-                    fprintf(stderr, "Invalid tree depth value: %s\n", argv[i]);
-                    fprintf(stderr, "Use -h or --help for usage information\n");
+                if (parse_positive_size_value(argv[++i], "tree depth", SIZE_MAX, &ctx.tree_depth) != 0) {
                     return 1;
                 }
             } else {
@@ -131,14 +224,35 @@ int main(int argc, char* argv[]) {
                 return 1;
             }
         } else if (strncmp(argv[i], "--tree-depth=", 13) == 0) {
-            char* endptr;
-            errno = 0;
-            unsigned long long depth = strtoull(argv[i] + 13, &endptr, 10);
-            if (*endptr == '\0' && depth > 0 && errno != ERANGE && depth <= SIZE_MAX) {
-                ctx.tree_depth = (size_t)depth;
+            if (parse_positive_size_value(argv[i] + 13, "tree depth", SIZE_MAX, &ctx.tree_depth) != 0) {
+                return 1;
+            }
+        } else if (strcmp(argv[i], "--warn-tokens") == 0) {
+            if (i + 1 < argc) {
+                if (parse_positive_size_value(argv[++i], "warn-tokens", SIZE_MAX, &ctx.warn_tokens) != 0) {
+                    return 1;
+                }
             } else {
-                fprintf(stderr, "Invalid tree depth value: %s\n", argv[i] + 13);
+                fprintf(stderr, "Missing value for --warn-tokens option\n");
                 fprintf(stderr, "Use -h or --help for usage information\n");
+                return 1;
+            }
+        } else if (strncmp(argv[i], "--warn-tokens=", 14) == 0) {
+            if (parse_positive_size_value(argv[i] + 14, "warn-tokens", SIZE_MAX, &ctx.warn_tokens) != 0) {
+                return 1;
+            }
+        } else if (strcmp(argv[i], "--max-tokens") == 0) {
+            if (i + 1 < argc) {
+                if (parse_positive_size_value(argv[++i], "max-tokens", SIZE_MAX, &ctx.max_tokens) != 0) {
+                    return 1;
+                }
+            } else {
+                fprintf(stderr, "Missing value for --max-tokens option\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return 1;
+            }
+        } else if (strncmp(argv[i], "--max-tokens=", 13) == 0) {
+            if (parse_positive_size_value(argv[i] + 13, "max-tokens", SIZE_MAX, &ctx.max_tokens) != 0) {
                 return 1;
             }
         } else if (strcmp(argv[i], "--staged") == 0) {
@@ -185,21 +299,7 @@ int main(int argc, char* argv[]) {
             }
             selection_mode = FILE_SELECTION_GIT_DIFF;
         } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
-            printf("Usage: %s [OPTIONS]\n", argv[0]);
-            printf("Export codebase to markdown file.\n\n");
-            printf("Options:\n");
-            printf("  -v, --verbose    Show progress information\n");
-            printf("  -s <size_kb>     Set maximum file size limit in KB (default: 100)\n");
-            printf("  -o, --output     Set output path (use '-' for stdout)\n");
-            printf("      --staged     Export staged files from the current Git subtree\n");
-            printf("      --unstaged   Export unstaged tracked files from the current Git subtree\n");
-            printf("      --diff <r>   Export files changed by a git diff range (for example main...HEAD)\n");
-            printf("                   Git file-selection flags are mutually exclusive\n");
-            printf("      --tree       Include a directory tree section (default)\n");
-            printf("      --no-tree    Omit the directory tree section\n");
-            printf("      --tree-depth Limit tree rendering depth to N levels\n");
-            printf("      --no-clobber Fail if output file already exists\n");
-            printf("  -h, --help       Show this help message\n");
+            print_usage(argv[0]);
             return 0;
         } else {
             fprintf(stderr, "Unknown option: %s\n", argv[i]);
@@ -220,24 +320,81 @@ int main(int argc, char* argv[]) {
     }
 
     if (ctx.output_is_stdout) {
-        output_file = stdout;
-        if (fstat(fileno(output_file), &ctx.final_stat) == 0 &&
+        if (fstat(fileno(stdout), &ctx.final_stat) == 0 &&
             S_ISREG(ctx.final_stat.st_mode)) {
             ctx.have_final = 1;
         }
     } else {
-        if (ctx.no_clobber) {
-            errno = 0;
-            if (stat(ctx.output_path, &ctx.final_stat) == 0) {
+        errno = 0;
+        if (stat(ctx.output_path, &ctx.final_stat) == 0) {
+            ctx.have_final = 1;
+            if (ctx.no_clobber) {
                 fprintf(stderr, "fuori: output file already exists: %s\n", ctx.output_path);
                 goto cleanup;
             }
-            if (errno != ENOENT) {
-                perror("Error checking output path");
-                goto cleanup;
-            }
+        } else if (errno != ENOENT) {
+            perror("Error checking output path");
+            goto cleanup;
         }
+    }
 
+    if (selection_mode == FILE_SELECTION_RECURSIVE) {
+        if (collect_recursive_export_plan(&ctx, &plan) != 0) {
+            fprintf(stderr, "Error collecting directory entries\n");
+            goto cleanup;
+        }
+    } else {
+        if (collect_selected_export_plan(selected_paths, selected_count, &ctx, &plan) != 0) {
+            fprintf(stderr, "Error collecting selected files\n");
+            goto cleanup;
+        }
+    }
+
+    if (calculate_export_metrics(&plan, selection_mode, ctx.show_tree, ctx.tree_depth, &metrics) != 0) {
+        perror("Error calculating export metrics");
+        goto cleanup;
+    }
+
+    if (ctx.max_tokens > 0 && metrics.estimated_tokens > ctx.max_tokens) {
+        char limit_buf[32];
+        char estimate_buf[32];
+
+        if (format_size_with_commas(ctx.max_tokens, limit_buf, sizeof(limit_buf)) != 0 ||
+            format_size_with_commas(metrics.estimated_tokens, estimate_buf, sizeof(estimate_buf)) != 0) {
+            fprintf(stderr,
+                    "Error: estimated output is ~%zu tokens, which exceeds --max-tokens %zu. "
+                    "Consider using --staged or --diff to narrow scope.\n",
+                    metrics.estimated_tokens,
+                    ctx.max_tokens);
+        } else {
+            fprintf(stderr,
+                    "Error: estimated output is ~%s tokens, which exceeds --max-tokens %s. "
+                    "Consider using --staged or --diff to narrow scope.\n",
+                    estimate_buf,
+                    limit_buf);
+        }
+        goto cleanup;
+    }
+
+    if (metrics.estimated_tokens > ctx.warn_tokens) {
+        char warn_buf[32];
+
+        if (format_size_with_commas(ctx.warn_tokens, warn_buf, sizeof(warn_buf)) != 0) {
+            fprintf(stderr,
+                    "Warning: output may exceed %zu token context window. "
+                    "Consider using --staged or --diff to narrow scope.\n",
+                    ctx.warn_tokens);
+        } else {
+            fprintf(stderr,
+                    "Warning: output may exceed %s token context window. "
+                    "Consider using --staged or --diff to narrow scope.\n",
+                    warn_buf);
+        }
+    }
+
+    if (ctx.output_is_stdout) {
+        output_file = stdout;
+    } else {
         if (make_temp_output_template(ctx.output_path, temp_output_path, sizeof(temp_output_path)) != 0) {
             perror("Error creating temporary output path");
             goto cleanup;
@@ -263,24 +420,11 @@ int main(int argc, char* argv[]) {
             goto cleanup;
         }
         ctx.have_temp = 1;
-        ctx.have_final = (stat(ctx.output_path, &ctx.final_stat) == 0);
     }
 
     if (write_export_header(output_file, selection_mode) != 0) {
         perror("Error writing output header");
         goto cleanup;
-    }
-
-    if (selection_mode == FILE_SELECTION_RECURSIVE) {
-        if (collect_recursive_export_plan(&ctx, &plan) != 0) {
-            fprintf(stderr, "Error collecting directory entries\n");
-            goto cleanup;
-        }
-    } else {
-        if (collect_selected_export_plan(selected_paths, selected_count, &ctx, &plan) != 0) {
-            fprintf(stderr, "Error collecting selected files\n");
-            goto cleanup;
-        }
     }
 
     if (ctx.show_tree) {
@@ -319,6 +463,8 @@ int main(int argc, char* argv[]) {
     } else {
         fprintf(stderr, "Codebase exported to stdout successfully!\n");
     }
+
+    print_export_summary(&metrics);
 
     status = 0;
 

--- a/render.c
+++ b/render.c
@@ -1,6 +1,7 @@
 #include "render.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -16,6 +17,33 @@ typedef struct TreeNode {
     size_t child_count;
     size_t child_capacity;
 } TreeNode;
+
+static int add_size(size_t* total, size_t amount) {
+    if (*total > SIZE_MAX - amount) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    *total += amount;
+    return 0;
+}
+
+static const char* export_description(FileSelectionMode mode) {
+    switch (mode) {
+        case FILE_SELECTION_GIT_STAGED:
+            return "This document contains staged files selected from the current Git subtree.\n\n";
+        case FILE_SELECTION_GIT_UNSTAGED:
+            return "This document contains unstaged tracked files selected from the current Git subtree.\n\n";
+        case FILE_SELECTION_GIT_DIFF:
+            return "This document contains files selected from the current Git subtree by the requested Git diff range.\n\n";
+        case FILE_SELECTION_RECURSIVE:
+        default:
+            return "This document contains all the source code files from the current directory subtree.\n\n";
+    }
+}
+
+static size_t estimate_tokens(size_t byte_count) {
+    return (byte_count / 7) * 2 + ((byte_count % 7) * 2) / 7;
+}
 
 static int write_text(FILE* out, const char* text) {
     return (fputs(text, out) == EOF) ? -1 : 0;
@@ -60,6 +88,14 @@ static int write_markdown_path(FILE* out, const char* path) {
 
     for (const unsigned char* p = (const unsigned char*)path; *p != '\0'; p++) {
         unsigned char c = *p;
+        if (c == '&') {
+            if (write_text(out, "&amp;") != 0) return -1;
+            continue;
+        }
+        if (c == '<') {
+            if (write_text(out, "&lt;") != 0) return -1;
+            continue;
+        }
         if (c == '\n') {
             if (write_text(out, "\\n") != 0) return -1;
             continue;
@@ -90,6 +126,62 @@ static int write_markdown_path(FILE* out, const char* path) {
     return 0;
 }
 
+static int count_text_bytes(size_t* total, const char* text) {
+    return add_size(total, strlen(text));
+}
+
+static int count_visible_text_bytes(size_t* total, const char* text) {
+    for (const unsigned char* p = (const unsigned char*)text; *p != '\0'; p++) {
+        unsigned char c = *p;
+        if (c == '\n' || c == '\r' || c == '\t') {
+            if (add_size(total, 2) != 0) return -1;
+            continue;
+        }
+        if ((c < 0x20 || c == 0x7f)) {
+            if (add_size(total, 4) != 0) return -1;
+            continue;
+        }
+        if (add_size(total, 1) != 0) return -1;
+    }
+    return 0;
+}
+
+static int count_markdown_path_bytes(size_t* total, const char* path) {
+    static const char markdown_meta[] = "\\`*_{}[]()#+-.!|>";
+
+    for (const unsigned char* p = (const unsigned char*)path; *p != '\0'; p++) {
+        unsigned char c = *p;
+        if (c == '&') {
+            if (add_size(total, strlen("&amp;")) != 0) return -1;
+            continue;
+        }
+        if (c == '<') {
+            if (add_size(total, strlen("&lt;")) != 0) return -1;
+            continue;
+        }
+        if (c == '\n' || c == '\r' || c == '\t') {
+            if (add_size(total, 2) != 0) return -1;
+            continue;
+        }
+        if ((c < 0x20 || c == 0x7f)) {
+            if (add_size(total, 4) != 0) return -1;
+            continue;
+        }
+        if (strchr(markdown_meta, c) != NULL) {
+            if (add_size(total, 2) != 0) return -1;
+            continue;
+        }
+        if (add_size(total, 1) != 0) return -1;
+    }
+    return 0;
+}
+
+static int count_fence_bytes(size_t* total, size_t count, const char* lang) {
+    if (add_size(total, count) != 0) return -1;
+    if (lang && *lang && add_size(total, strlen(lang)) != 0) return -1;
+    return add_size(total, 1);
+}
+
 static int write_fence(FILE* out, size_t count, const char* lang) {
     for (size_t i = 0; i < count; i++) {
         if (fputc('`', out) == EOF) return -1;
@@ -103,21 +195,7 @@ int write_export_header(FILE* out, FileSelectionMode mode) {
         return -1;
     }
 
-    switch (mode) {
-        case FILE_SELECTION_GIT_STAGED:
-            return write_text(out,
-                              "This document contains staged files selected from the current Git subtree.\n\n");
-        case FILE_SELECTION_GIT_UNSTAGED:
-            return write_text(out,
-                              "This document contains unstaged tracked files selected from the current Git subtree.\n\n");
-        case FILE_SELECTION_GIT_DIFF:
-            return write_text(out,
-                              "This document contains files selected from the current Git subtree by the requested Git diff range.\n\n");
-        case FILE_SELECTION_RECURSIVE:
-        default:
-            return write_text(out,
-                              "This document contains all the source code files from the current directory subtree.\n\n");
-    }
+    return write_text(out, export_description(mode));
 }
 
 static TreeNode* tree_node_create(const char* name, int is_dir) {
@@ -255,6 +333,41 @@ static int write_tree_children(FILE* out,
     return 0;
 }
 
+static int count_tree_children_bytes(const TreeNode* node,
+                                     size_t prefix_len,
+                                     size_t depth,
+                                     size_t max_depth,
+                                     size_t* total) {
+    for (size_t i = 0; i < node->child_count; i++) {
+        const TreeNode* child = node->children[i];
+        int is_last = (i + 1 == node->child_count);
+        const char* branch = is_last ? TREE_LAST : TREE_BRANCH;
+
+        if (add_size(total, prefix_len) != 0 ||
+            add_size(total, strlen(branch)) != 0 ||
+            count_visible_text_bytes(total, child->name) != 0 ||
+            add_size(total, 1) != 0) {
+            return -1;
+        }
+
+        if (child->is_dir &&
+            child->child_count > 0 &&
+            (max_depth == SIZE_MAX || depth < max_depth)) {
+            const char* segment = is_last ? TREE_SPACE : TREE_PIPE;
+            size_t next_prefix_len = prefix_len + strlen(segment);
+            if (next_prefix_len < prefix_len) {
+                errno = EOVERFLOW;
+                return -1;
+            }
+            if (count_tree_children_bytes(child, next_prefix_len, depth + 1, max_depth, total) != 0) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
 int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
     TreeNode* root = tree_node_create("", 1);
     if (!root) {
@@ -286,6 +399,105 @@ int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
 
     free_tree(root);
     return write_text(out, "```\n\n");
+}
+
+static int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total) {
+    TreeNode* root = tree_node_create("", 1);
+    if (!root) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < plan->count; i++) {
+        if (tree_add_path(root, plan->entries[i].display_path) != 0) {
+            free_tree(root);
+            return -1;
+        }
+    }
+    sort_tree(root);
+
+    if (count_text_bytes(total, "## Project Tree\n\n```text\n") != 0) {
+        free_tree(root);
+        return -1;
+    }
+
+    if (root->child_count == 0) {
+        if (count_text_bytes(total, "(no exported files)\n") != 0) {
+            free_tree(root);
+            return -1;
+        }
+    } else if (count_tree_children_bytes(root, 0, 1, max_depth, total) != 0) {
+        free_tree(root);
+        return -1;
+    }
+
+    free_tree(root);
+    return count_text_bytes(total, "```\n\n");
+}
+
+static int count_entry_bytes(const ExportEntry* entry, size_t* total) {
+    size_t max_run = 0;
+    size_t current_run = 0;
+    size_t fence = 3;
+
+    for (size_t i = 0; i < entry->buf_len; i++) {
+        if (entry->buf[i] == '`') {
+            current_run++;
+            if (current_run > max_run) max_run = current_run;
+        } else {
+            current_run = 0;
+        }
+    }
+    fence = (max_run >= 3 ? max_run + 1 : 3);
+
+    if (count_text_bytes(total, "## ") != 0 ||
+        count_markdown_path_bytes(total, entry->display_path) != 0 ||
+        count_text_bytes(total, "\n\n") != 0 ||
+        count_fence_bytes(total, fence, entry->lang) != 0 ||
+        add_size(total, entry->buf_len) != 0) {
+        return -1;
+    }
+    if (entry->buf_len > 0 && entry->buf[entry->buf_len - 1] != '\n' &&
+        add_size(total, 1) != 0) {
+        return -1;
+    }
+    if (count_fence_bytes(total, fence, NULL) != 0 ||
+        count_text_bytes(total, "\n\n") != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int calculate_export_metrics(const ExportPlan* plan,
+                             FileSelectionMode mode,
+                             int show_tree,
+                             size_t tree_depth,
+                             ExportMetrics* metrics) {
+    size_t total = 0;
+
+    if (!plan || !metrics) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (count_text_bytes(&total, "# Codebase Export\n\n") != 0 ||
+        count_text_bytes(&total, export_description(mode)) != 0) {
+        return -1;
+    }
+
+    if (show_tree && count_project_tree_bytes(plan, tree_depth, &total) != 0) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < plan->count; i++) {
+        if (count_entry_bytes(&plan->entries[i], &total) != 0) {
+            return -1;
+        }
+    }
+
+    metrics->files_exported = plan->count;
+    metrics->bytes_written = total;
+    metrics->estimated_tokens = estimate_tokens(total);
+    return 0;
 }
 
 static int render_entry(FILE* out, const ExportEntry* entry) {

--- a/render.h
+++ b/render.h
@@ -6,6 +6,17 @@
 #include "app.h"
 #include "collect.h"
 
+typedef struct {
+    size_t files_exported;
+    size_t bytes_written;
+    size_t estimated_tokens;
+} ExportMetrics;
+
+int calculate_export_metrics(const ExportPlan* plan,
+                             FileSelectionMode mode,
+                             int show_tree,
+                             size_t tree_depth,
+                             ExportMetrics* metrics);
 int write_export_header(FILE* out, FileSelectionMode mode);
 int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth);
 int render_export_plan(FILE* out, const ExportPlan* plan, int verbose);


### PR DESCRIPTION
Adds lightweight token-budget estimation based on the final Markdown artifact, using a conservative integer approximation of ~3.5 chars/token.