### PR TITLE
fix: no-space-for-terminator

### DIFF
--- a/ignore.c
+++ b/ignore.c
@@ -51,14 +51,14 @@ int resolve_ignore_state(const char* filepath,
         const char* pat = pattern;
         if (pattern_is_dir_only) {
             if (plen > scratch_cap) {
-                char* new_scratch = realloc(scratch, plen);
+                char* new_scratch = realloc(scratch, plen + 1);
                 if (!new_scratch) {
                     free(scratch);
                     // Fail closed: if we cannot evaluate ignore patterns, exclude the path.
                     return 1;
                 }
                 scratch = new_scratch;
-                scratch_cap = plen;
+                scratch_cap = plen + 1;
             }
             memcpy(scratch, pattern, plen - 1);
             scratch[plen - 1] = '\0';


### PR DESCRIPTION
Adjusted ignore.c (line 54) to allocate plen + 1 bytes for the scratch buffer and track that full capacity. The old code was effectively safe because it reused the trailing / slot as the terminator, but the new form is clearer and satisfies CodeQL.