### PR TITLE
support recursive ** path globs in ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /fuori
+/test_ignore
 /_export.md
 
 # macOS

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CFLAGS = -Wall -Wextra -Wshadow -Wcast-align -Wwrite-strings -Wredundant-decls \
          -Wstrict-prototypes -Wold-style-definition -std=c99 -O2 -D_POSIX_C_SOURCE=200809L
 TARGET = fuori
 SOURCES = main.c collect.c render.c git_paths.c ignore.c
+TEST_TARGET = test_ignore
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 VERSION ?= dev
@@ -13,8 +14,14 @@ all: $(TARGET)
 $(TARGET): $(SOURCES)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $(TARGET) $(SOURCES)
 
+$(TEST_TARGET): test_ignore.c ignore.c ignore.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $(TEST_TARGET) test_ignore.c ignore.c
+
+test: $(TEST_TARGET)
+	./$(TEST_TARGET)
+
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(TEST_TARGET)
 
 install: $(TARGET)
 	install -d $(BINDIR)

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ fuori --help
 ## .gitignore File
 
 You can create a `.gitignore` file in the directory to specify files and patterns to exclude from the export.
-This tool supports common gitignore-style rules (comments, `!` negation, trailing `/` for directories),
-but does not implement recursive `**` glob semantics.
+This tool supports common gitignore-style rules, including comments, `!` negation, trailing `/` for directories,
+root-anchored `/` patterns, and recursive `**` path globs such as `**/node_modules/` and `**/*.pyc`.
 
 ```
 # Ignore build directories

--- a/app.h
+++ b/app.h
@@ -14,6 +14,8 @@
 #define DEFAULT_OUTPUT_FILE "_export.md"
 #define DEFAULT_WARN_TOKENS 200000
 
+struct IgnorePattern;
+
 typedef struct {
     int verbose;
     int no_clobber;
@@ -24,7 +26,7 @@ typedef struct {
     size_t warn_tokens;
     size_t max_tokens;
     const char* output_path;
-    char** ignore_patterns;
+    IgnorePattern* ignore_patterns;
     size_t ignore_count;
     struct stat temp_stat;
     struct stat final_stat;

--- a/collect.c
+++ b/collect.c
@@ -296,7 +296,7 @@ static int should_exclude_file(const char* filepath,
                                const struct stat* st,
                                size_t max_file_size,
                                int ancestor_ignored,
-                               char** patterns,
+                               const IgnorePattern* patterns,
                                size_t count) {
     if (!S_ISREG(st->st_mode)) {
         return 1;

--- a/ignore.c
+++ b/ignore.c
@@ -6,17 +6,227 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void cleanup_patterns(char*** patterns, size_t count) {
+typedef struct {
+    char* storage;
+    char** items;
+    size_t count;
+} PathSegments;
+
+static void free_compiled_segments(IgnorePattern* pattern) {
+    if (!pattern) return;
+    free(pattern->segment_items);
+    free(pattern->segment_storage);
+    pattern->segment_items = NULL;
+    pattern->segment_storage = NULL;
+    pattern->segment_count = 0;
+}
+
+static void free_pattern_fields(IgnorePattern* pattern) {
+    if (!pattern) return;
+    free(pattern->match_pattern);
+    pattern->match_pattern = NULL;
+    free_compiled_segments(pattern);
+    pattern->negated = 0;
+    pattern->dir_only = 0;
+    pattern->root_anchored = 0;
+    pattern->use_path_match = 0;
+}
+
+static void cleanup_patterns(IgnorePattern** patterns, size_t count) {
     if (!patterns || !*patterns) return;
     for (size_t i = 0; i < count; i++) {
-        free((*patterns)[i]);
+        free_pattern_fields(&(*patterns)[i]);
     }
     free(*patterns);
     *patterns = NULL;
 }
 
+static void free_path_segments(PathSegments* segments) {
+    if (!segments) return;
+    free(segments->items);
+    free(segments->storage);
+    segments->items = NULL;
+    segments->storage = NULL;
+    segments->count = 0;
+}
+
+static int split_path_segments(const char* path, PathSegments* segments) {
+    char* storage = NULL;
+    char** items = NULL;
+    size_t count = 0;
+    size_t capacity = 0;
+    char* cursor;
+
+    if (!path || !segments) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    storage = strdup(path);
+    if (!storage) {
+        return -1;
+    }
+
+    cursor = storage;
+    while (*cursor != '\0') {
+        while (*cursor == '/') {
+            cursor++;
+        }
+        if (*cursor == '\0') {
+            break;
+        }
+
+        if (count == capacity) {
+            size_t new_capacity = (capacity == 0) ? 8 : capacity * 2;
+            char** new_items = realloc(items, new_capacity * sizeof(*new_items));
+            if (!new_items) {
+                free(items);
+                free(storage);
+                return -1;
+            }
+            items = new_items;
+            capacity = new_capacity;
+        }
+
+        items[count++] = cursor;
+        while (*cursor != '\0' && *cursor != '/') {
+            cursor++;
+        }
+        if (*cursor == '/') {
+            *cursor++ = '\0';
+        }
+    }
+
+    segments->storage = storage;
+    segments->items = items;
+    segments->count = count;
+    return 0;
+}
+
+static int compile_segments(const char* path,
+                            char** storage_out,
+                            char*** items_out,
+                            size_t* count_out) {
+    PathSegments segments = {0};
+
+    if (!storage_out || !items_out || !count_out) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (split_path_segments(path, &segments) != 0) {
+        return -1;
+    }
+
+    *storage_out = segments.storage;
+    *items_out = segments.items;
+    *count_out = segments.count;
+    return 0;
+}
+
+static int is_double_star_segment(const char* segment) {
+    return segment != NULL && strcmp(segment, "**") == 0;
+}
+
+static int match_segment_lists(char* const* pattern_items,
+                               size_t pattern_count,
+                               size_t pattern_index,
+                               const PathSegments* path_segments,
+                               size_t path_index) {
+    while (pattern_index < pattern_count) {
+        const char* pattern = pattern_items[pattern_index];
+
+        if (is_double_star_segment(pattern)) {
+            while (pattern_index + 1 < pattern_count &&
+                   is_double_star_segment(pattern_items[pattern_index + 1])) {
+                pattern_index++;
+            }
+
+            if (pattern_index + 1 == pattern_count) {
+                return 1;
+            }
+
+            for (size_t i = path_index; i <= path_segments->count; i++) {
+                if (match_segment_lists(pattern_items, pattern_count, pattern_index + 1, path_segments, i)) {
+                    return 1;
+                }
+            }
+            return 0;
+        }
+
+        if (path_index >= path_segments->count) {
+            return 0;
+        }
+
+        if (fnmatch(pattern, path_segments->items[path_index], 0) != 0) {
+            return 0;
+        }
+
+        pattern_index++;
+        path_index++;
+    }
+
+    return path_index == path_segments->count;
+}
+
+static int compile_ignore_pattern(const char* raw_pattern, IgnorePattern* pattern) {
+    const char* source = raw_pattern;
+    size_t length;
+    size_t normalized_start;
+    size_t normalized_len;
+
+    if (!raw_pattern || !pattern) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    memset(pattern, 0, sizeof(*pattern));
+
+    if (source[0] == '!') {
+        pattern->negated = 1;
+        source++;
+    }
+
+    length = strlen(source);
+    if (length == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    pattern->dir_only = (source[length - 1] == '/');
+    pattern->root_anchored = (source[0] == '/');
+    normalized_start = pattern->root_anchored ? 1 : 0;
+    normalized_len = length - normalized_start - (pattern->dir_only ? 1 : 0);
+    if (normalized_len == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    pattern->match_pattern = malloc(normalized_len + 1);
+    if (!pattern->match_pattern) {
+        return -1;
+    }
+    memcpy(pattern->match_pattern, source + normalized_start, normalized_len);
+    pattern->match_pattern[normalized_len] = '\0';
+
+    pattern->use_path_match = (pattern->root_anchored || strchr(pattern->match_pattern, '/') != NULL);
+    if (!pattern->use_path_match) {
+        return 0;
+    }
+
+    if (compile_segments(pattern->match_pattern,
+                         &pattern->segment_storage,
+                         &pattern->segment_items,
+                         &pattern->segment_count) != 0) {
+        free_pattern_fields(pattern);
+        return -1;
+    }
+
+    return 0;
+}
+
 int resolve_ignore_state(const char* filepath,
-                         char** patterns,
+                         const IgnorePattern* patterns,
                          size_t count,
                          int is_dir,
                          int initial_ignored) {
@@ -26,68 +236,48 @@ int resolve_ignore_state(const char* filepath,
     const char* base = strrchr(rel, '/');
     base = (base) ? base + 1 : rel;
 
-    char* scratch = NULL;
-    size_t scratch_cap = 0;
+    PathSegments rel_segments = {0};
+    int rel_segments_ready = 0;
     int ignored = initial_ignored;
     for (size_t i = 0; i < count; i++) {
-        char* raw_pattern = patterns[i];
-        size_t plen = strlen(raw_pattern);
-        if (plen == 0) continue;
+        const IgnorePattern* pattern = &patterns[i];
 
-        int negated = 0;
-        const char* pattern = raw_pattern;
-        if (pattern[0] == '!') {
-            negated = 1;
-            pattern++;
-            plen--;
-            if (plen == 0) continue;
-        }
-
-        int pattern_is_dir_only = (pattern[plen - 1] == '/');
-        if (pattern_is_dir_only && !is_dir) {
+        if (pattern->dir_only && !is_dir) {
             continue;
         }
 
-        const char* pat = pattern;
-        if (pattern_is_dir_only) {
-            if (plen > scratch_cap) {
-                char* new_scratch = realloc(scratch, plen + 1);
-                if (!new_scratch) {
-                    free(scratch);
-                    // Fail closed: if we cannot evaluate ignore patterns, exclude the path.
-                    return 1;
-                }
-                scratch = new_scratch;
-                scratch_cap = plen + 1;
+        if (!pattern->use_path_match) {
+            if (fnmatch(pattern->match_pattern, base, 0) == 0) {
+                ignored = !pattern->negated;
             }
-            memcpy(scratch, pattern, plen - 1);
-            scratch[plen - 1] = '\0';
-            pat = scratch;
+            continue;
         }
-        int has_slash = (strchr(pat, '/') != NULL);
-        if (has_slash) {
-            const char* match_pat = pat;
-            const char* match_target = rel;
-            if (pat[0] == '/') {
-                match_pat = pat + 1;
+
+        if (!rel_segments_ready) {
+            if (split_path_segments(rel, &rel_segments) != 0) {
+                return 1;
             }
-            if (fnmatch(match_pat, match_target, FNM_PATHNAME) == 0) {
-                ignored = !negated;
-            }
-        } else if (fnmatch(pat, base, FNM_PATHNAME) == 0) {
-            ignored = !negated;
+            rel_segments_ready = 1;
+        }
+
+        if (match_segment_lists(pattern->segment_items,
+                                pattern->segment_count,
+                                0,
+                                &rel_segments,
+                                0)) {
+            ignored = !pattern->negated;
         }
     }
 
-    free(scratch);
+    free_path_segments(&rel_segments);
     return ignored;
 }
 
-int is_ignored(const char* filepath, char** patterns, size_t count, int is_dir) {
+int is_ignored(const char* filepath, const IgnorePattern* patterns, size_t count, int is_dir) {
     return resolve_ignore_state(filepath, patterns, count, is_dir, 0);
 }
 
-int load_ignore_patterns(const char* ignore_file, char*** patterns, size_t* count) {
+int load_ignore_patterns(const char* ignore_file, IgnorePattern** patterns, size_t* count) {
     const char* default_ignores[] = {
         ".git/",
         "node_modules/",
@@ -113,15 +303,14 @@ int load_ignore_patterns(const char* ignore_file, char*** patterns, size_t* coun
     }
 
     size_t capacity = default_count + 16;
-    *patterns = malloc(capacity * sizeof(char*));
+    *patterns = calloc(capacity, sizeof(**patterns));
     if (!*patterns) {
         return -1;
     }
     *count = 0;
 
     for (size_t i = 0; i < default_count; i++) {
-        (*patterns)[*count] = strdup(default_ignores[i]);
-        if (!(*patterns)[*count]) {
+        if (compile_ignore_pattern(default_ignores[i], &(*patterns)[*count]) != 0) {
             cleanup_patterns(patterns, *count);
             return -1;
         }
@@ -154,7 +343,7 @@ int load_ignore_patterns(const char* ignore_file, char*** patterns, size_t* coun
 
         if (*count >= capacity) {
             capacity *= 2;
-            char** new_patterns = realloc(*patterns, capacity * sizeof(char*));
+            IgnorePattern* new_patterns = realloc(*patterns, capacity * sizeof(*new_patterns));
             if (!new_patterns) {
                 free(line);
                 fclose(file);
@@ -165,8 +354,7 @@ int load_ignore_patterns(const char* ignore_file, char*** patterns, size_t* coun
             *patterns = new_patterns;
         }
 
-        (*patterns)[*count] = strdup(line);
-        if (!(*patterns)[*count]) {
+        if (compile_ignore_pattern(line, &(*patterns)[*count]) != 0) {
             free(line);
             fclose(file);
             cleanup_patterns(patterns, *count);
@@ -194,10 +382,10 @@ int load_ignore_patterns(const char* ignore_file, char*** patterns, size_t* coun
     return 0;
 }
 
-void free_ignore_patterns(char** patterns, size_t count) {
+void free_ignore_patterns(IgnorePattern* patterns, size_t count) {
     if (!patterns) return;
     for (size_t i = 0; i < count; i++) {
-        free(patterns[i]);
+        free_pattern_fields(&patterns[i]);
     }
     free(patterns);
 }

--- a/ignore.h
+++ b/ignore.h
@@ -3,13 +3,24 @@
 
 #include <stddef.h>
 
-int is_ignored(const char* filepath, char** patterns, size_t count, int is_dir);
+typedef struct IgnorePattern {
+    char* match_pattern;
+    char* segment_storage;
+    char** segment_items;
+    size_t segment_count;
+    int negated;
+    int dir_only;
+    int root_anchored;
+    int use_path_match;
+} IgnorePattern;
+
+int is_ignored(const char* filepath, const IgnorePattern* patterns, size_t count, int is_dir);
 int resolve_ignore_state(const char* filepath,
-                         char** patterns,
+                         const IgnorePattern* patterns,
                          size_t count,
                          int is_dir,
                          int initial_ignored);
-int load_ignore_patterns(const char* ignore_file, char*** patterns, size_t* count);
-void free_ignore_patterns(char** patterns, size_t count);
+int load_ignore_patterns(const char* ignore_file, IgnorePattern** patterns, size_t* count);
+void free_ignore_patterns(IgnorePattern* patterns, size_t count);
 
 #endif

--- a/test_ignore.c
+++ b/test_ignore.c
@@ -1,0 +1,164 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "ignore.h"
+
+typedef struct {
+    const char* name;
+    const char* path;
+    int is_dir;
+    int initial_ignored;
+    int expected;
+    const char* patterns[8];
+} IgnoreCase;
+
+static int run_case(const IgnoreCase* test_case) {
+    IgnorePattern* patterns = NULL;
+    size_t count = 0;
+    int fd = -1;
+    FILE* file = NULL;
+    char template[] = "/tmp/fuori-ignore-test.XXXXXX";
+    int actual;
+    int failed = 0;
+
+    while (count < 8 && test_case->patterns[count] != NULL) {
+        count++;
+    }
+
+    fd = mkstemp(template);
+    if (fd < 0) {
+        perror("mkstemp");
+        return 1;
+    }
+
+    file = fdopen(fd, "w");
+    if (!file) {
+        perror("fdopen");
+        close(fd);
+        unlink(template);
+        return 1;
+    }
+    fd = -1;
+
+    for (size_t i = 0; i < count; i++) {
+        if (fprintf(file, "%s\n", test_case->patterns[i]) < 0) {
+            perror("fprintf");
+            fclose(file);
+            unlink(template);
+            return 1;
+        }
+    }
+    if (fclose(file) != 0) {
+        perror("fclose");
+        unlink(template);
+        return 1;
+    }
+
+    if (load_ignore_patterns(template, &patterns, &count) != 0) {
+        perror("load_ignore_patterns");
+        unlink(template);
+        return 1;
+    }
+
+    actual = resolve_ignore_state(test_case->path,
+                                  patterns,
+                                  count,
+                                  test_case->is_dir,
+                                  test_case->initial_ignored);
+    if (actual != test_case->expected) {
+        fprintf(stderr,
+                "FAIL %-28s path=%s expected=%d actual=%d\n",
+                test_case->name,
+                test_case->path,
+                test_case->expected,
+                actual);
+        failed = 1;
+    }
+
+    free_ignore_patterns(patterns, count);
+    unlink(template);
+    return failed;
+}
+
+int main(void) {
+    const IgnoreCase cases[] = {
+        {
+            .name = "basename directory ignore",
+            .path = "apps/web/node_modules",
+            .is_dir = 1,
+            .expected = 1,
+            .patterns = {"node_modules/", NULL}
+        },
+        {
+            .name = "recursive double-star directory",
+            .path = "apps/web/node_modules",
+            .is_dir = 1,
+            .expected = 1,
+            .patterns = {"**/node_modules/", NULL}
+        },
+        {
+            .name = "recursive double-star file",
+            .path = "pkg/cache/module.pyc",
+            .is_dir = 0,
+            .expected = 1,
+            .patterns = {"**/*.pyc", NULL}
+        },
+        {
+            .name = "double-star matches root file",
+            .path = "module.pyc",
+            .is_dir = 0,
+            .expected = 1,
+            .patterns = {"**/*.pyc", NULL}
+        },
+        {
+            .name = "root anchored directory only",
+            .path = "src/cache-dir",
+            .is_dir = 1,
+            .expected = 0,
+            .patterns = {"/cache-dir/", NULL}
+        },
+        {
+            .name = "root anchored root match",
+            .path = "cache-dir",
+            .is_dir = 1,
+            .expected = 1,
+            .patterns = {"/cache-dir/", NULL}
+        },
+        {
+            .name = "slash pattern stays rooted",
+            .path = "lib/src/main.c",
+            .is_dir = 0,
+            .expected = 0,
+            .patterns = {"src/*.c", NULL}
+        },
+        {
+            .name = "slash pattern root hit",
+            .path = "src/main.c",
+            .is_dir = 0,
+            .expected = 1,
+            .patterns = {"src/*.c", NULL}
+        },
+        {
+            .name = "negation restores file",
+            .path = "src/keep.pyc",
+            .is_dir = 0,
+            .expected = 0,
+            .patterns = {"**/*.pyc", "!src/keep.pyc", NULL}
+        }
+    };
+
+    int failures = 0;
+    size_t count = sizeof(cases) / sizeof(cases[0]);
+    for (size_t i = 0; i < count; i++) {
+        failures += run_case(&cases[i]);
+    }
+
+    if (failures != 0) {
+        return 1;
+    }
+
+    printf("ignore tests passed (%zu cases)\n", count);
+    return 0;
+}


### PR DESCRIPTION
`fuori` now understands recursive ** path globs in ignore patterns via a small segment-based matcher.