### PR TITLE
add auto-Git default export mode with filesystem fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ $(TARGET): $(SOURCES)
 $(TEST_TARGET): test_ignore.c ignore.c ignore.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $(TEST_TARGET) test_ignore.c ignore.c
 
-test: $(TEST_TARGET)
+test: $(TARGET) $(TEST_TARGET)
 	./$(TEST_TARGET)
+	BIN=./$(TARGET) sh ./test_cli.sh
 
 clean:
 	rm -f $(TARGET) $(TEST_TARGET)
@@ -27,4 +28,4 @@ install: $(TARGET)
 	install -d $(BINDIR)
 	install -m 755 $(TARGET) $(BINDIR)
 
-.PHONY: all clean install
+.PHONY: all clean install test

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A C application that exports a codebase to a single Markdown file with UTF-8 enc
 ## Features
 
 - **Context packing for LLMs**: export a codebase into a single Markdown artifact for AI assistants
-- Recursively scans the current directory for source code files
-- Git-aware file selection via `--staged`, `--unstaged`, or `--diff <range>`
+- Auto-detects Git worktrees by default and falls back to recursive filesystem scanning elsewhere
+- Git-aware file selection via the default worktree mode, `--staged`, `--unstaged`, or `--diff <range>`
 - Includes a project tree that matches the exported artifact
-- Respects exclusions defined in a `.gitignore` file
+- Respects Git ignore rules in Git-backed modes and local ignore rules in filesystem mode
 - Automatically detects and excludes binary files
 - Excludes files larger than 100KB (configurable)
 - Formats code in Markdown with appropriate language identifiers
@@ -53,7 +53,7 @@ Run `fuori` in any directory you want to export:
 ./fuori
 ```
 
-By default, the application creates a file named `_export.md` in the current directory containing all source code files in markdown format.
+By default, the application creates a file named `_export.md` in the current directory containing all source code files in markdown format. Inside a Git repository, it prefers Git's view of the current subtree (tracked files plus untracked non-ignored files); outside a repository, or when you pass `--no-git`, it falls back to the recursive filesystem walker.
 
 ### Command Line Options
 
@@ -66,6 +66,7 @@ By default, the application creates a file named `_export.md` in the current dir
 - `-v, --verbose`: Show progress information during processing
 - `-s <size_kb>`: Set maximum file size limit in KB (default: 100)
 - `-o, --output <path>`: Set output path (use `-` for stdout)
+- `--no-git`: Force recursive filesystem selection instead of the default auto-Git behavior
 - `--staged`: Export staged files from the current Git subtree
 - `--unstaged`: Export unstaged tracked files from the current Git subtree
 - `--diff <range>` / `--diff=<range>`: Export files changed by a Git diff range
@@ -77,12 +78,15 @@ By default, the application creates a file named `_export.md` in the current dir
 - `--no-clobber`: Fail if output file already exists
 - `-h, --help`: Display help message
 
-Git file-selection modes are mutually exclusive: use at most one of `--staged`, `--unstaged`, or `--diff`.
+Git file-selection modes are mutually exclusive: use at most one of `--staged`, `--unstaged`, or `--diff`. `--no-git` cannot be combined with those explicit Git selection flags.
 
 **Examples:**
 ```bash
 # Basic usage
 fuori
+
+# Force filesystem recursion even inside a Git repository
+fuori --no-git
 
 # Show version
 fuori --version
@@ -133,6 +137,7 @@ fuori --help
 ## .gitignore File
 
 You can create a `.gitignore` file in the directory to specify files and patterns to exclude from the export.
+These rules apply to the recursive filesystem walker, including `--no-git` mode and automatic fallback outside Git repositories.
 This tool supports common gitignore-style rules, including comments, `!` negation, trailing `/` for directories,
 root-anchored `/` patterns, and recursive `**` path globs such as `**/node_modules/` and `**/*.pyc`.
 
@@ -155,15 +160,20 @@ Files larger than the specified size limit (default 100KB) are automatically exc
 
 ## Git File Selection
 
+When you run `fuori` without file-selection flags inside a Git repository, it asks Git for the current subtree's tracked files plus untracked non-ignored files by running `git ls-files -z --cached --others --exclude-standard`. If Git is unavailable or the current directory is not inside a repository, `fuori` silently falls back to the recursive filesystem walker.
+
+Use `--no-git` to force the recursive filesystem walker even inside a Git repository.
+
 When you use `--staged`, `--unstaged`, or `--diff`, `fuori` asks Git for an explicit file list instead of recursively walking the tree.
 
+- Default mode uses tracked files plus untracked non-ignored files (`git ls-files -z --cached --others --exclude-standard`)
 - `--staged` uses staged files in `AMR` (`git diff --cached --name-only --diff-filter=AMR`)
 - `--unstaged` uses tracked unstaged files in `AMR` (`git diff --name-only --diff-filter=AMR`)
 - `--diff <range>` passes `<range>` directly to `git diff`, so both two-dot and three-dot ranges work, including examples like `HEAD~3..HEAD`, `main...HEAD`, and `v1.2.0..HEAD`
 
 Additional semantics:
 
-- Git file-selection modes are scoped to the current working directory subtree when run from a Git subdirectory
+- The default Git-backed mode and explicit Git file-selection modes are scoped to the current working directory subtree when run from a Git subdirectory
 - Git-selected files bypass selection-time ignore rules such as `.gitignore`
 - Git-selected files still go through normal export-time checks such as regular-file validation, symlink skipping, binary detection, size limits, and output-file self-exclusion
 - `--unstaged` does not include untracked files

--- a/app.h
+++ b/app.h
@@ -26,7 +26,7 @@ typedef struct {
     size_t warn_tokens;
     size_t max_tokens;
     const char* output_path;
-    IgnorePattern* ignore_patterns;
+    struct IgnorePattern* ignore_patterns;
     size_t ignore_count;
     struct stat temp_stat;
     struct stat final_stat;
@@ -35,7 +35,9 @@ typedef struct {
 } AppContext;
 
 typedef enum {
-    FILE_SELECTION_RECURSIVE = 0,
+    FILE_SELECTION_AUTO = 0,
+    FILE_SELECTION_RECURSIVE,
+    FILE_SELECTION_GIT_WORKTREE,
     FILE_SELECTION_GIT_STAGED,
     FILE_SELECTION_GIT_UNSTAGED,
     FILE_SELECTION_GIT_DIFF

--- a/git_paths.c
+++ b/git_paths.c
@@ -9,6 +9,11 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+typedef enum {
+    GIT_PROBE_READY = 0,
+    GIT_PROBE_FALLBACK
+} GitProbeResult;
+
 static int compare_selected_paths(const void* lhs, const void* rhs) {
     const SelectedPath* left = lhs;
     const SelectedPath* right = rhs;
@@ -162,7 +167,11 @@ cleanup:
     return status;
 }
 
-static int capture_git_line(const char* repo_root, const char* rev_parse_arg, char** line_out) {
+static int capture_git_line(const char* repo_root,
+                            const char* rev_parse_arg,
+                            int quiet_probe,
+                            char** line_out,
+                            GitProbeResult* probe_result) {
     const char* const argv[] = {"git", "-C", repo_root, "rev-parse", rev_parse_arg, NULL};
     unsigned char* output = NULL;
     size_t output_len = 0;
@@ -170,19 +179,34 @@ static int capture_git_line(const char* repo_root, const char* rev_parse_arg, ch
     int exec_errno = 0;
 
     *line_out = NULL;
+    if (probe_result) {
+        *probe_result = GIT_PROBE_READY;
+    }
     if (run_command_capture(argv, &output, &output_len, &exit_status, &exec_errno) != 0) {
         perror("Error running git");
         return -1;
     }
     if (exec_errno != 0) {
         errno = exec_errno;
-        perror("Error executing git");
+        if (quiet_probe && errno == ENOENT) {
+            if (probe_result) {
+                *probe_result = GIT_PROBE_FALLBACK;
+            }
+        } else {
+            perror("Error executing git");
+        }
         free(output);
         return -1;
     }
     if (!WIFEXITED(exit_status) || WEXITSTATUS(exit_status) != 0) {
         errno = 0;
-        fprintf(stderr, "git rev-parse failed for %s\n", rev_parse_arg);
+        if (quiet_probe) {
+            if (probe_result) {
+                *probe_result = GIT_PROBE_FALLBACK;
+            }
+        } else {
+            fprintf(stderr, "git rev-parse failed for %s\n", rev_parse_arg);
+        }
         free(output);
         return -1;
     }
@@ -205,120 +229,85 @@ static int capture_git_line(const char* repo_root, const char* rev_parse_arg, ch
     return 0;
 }
 
-int collect_git_paths(FileSelectionMode mode,
-                      const char* diff_range,
-                      SelectedPath** paths_out,
-                      size_t* count_out) {
-    char* repo_root = NULL;
-    char* prefix = NULL;
-    const char* diff_filter = "--diff-filter=AMR";
-    const char* const* argv = NULL;
-    const char* args[12];
-    unsigned char* output = NULL;
-    size_t output_len = 0;
-    int exit_status = 0;
-    int exec_errno = 0;
+static int append_selected_path(SelectedPath** paths,
+                                size_t* count,
+                                size_t* capacity,
+                                const char* repo_root,
+                                size_t repo_root_len,
+                                const char* prefix,
+                                size_t prefix_len,
+                                const char* repo_rel,
+                                size_t repo_rel_len) {
+    const char* display_rel = repo_rel;
+    if (prefix_len > 0 &&
+        strncmp(repo_rel, prefix, prefix_len) == 0) {
+        display_rel = repo_rel + prefix_len;
+    }
+
+    if (*count == *capacity) {
+        size_t new_capacity = (*capacity == 0) ? 16 : *capacity * 2;
+        SelectedPath* new_paths = realloc(*paths, new_capacity * sizeof(**paths));
+        if (!new_paths) {
+            return -1;
+        }
+        *paths = new_paths;
+        *capacity = new_capacity;
+    }
+
+    size_t open_path_len = repo_root_len + 1 + repo_rel_len;
+    (*paths)[*count].open_path = malloc(open_path_len + 1);
+    if (!(*paths)[*count].open_path) {
+        return -1;
+    }
+    memcpy((*paths)[*count].open_path, repo_root, repo_root_len);
+    (*paths)[*count].open_path[repo_root_len] = '/';
+    memcpy((*paths)[*count].open_path + repo_root_len + 1, repo_rel, repo_rel_len);
+    (*paths)[*count].open_path[open_path_len] = '\0';
+
+    (*paths)[*count].display_path = strdup(display_rel);
+    if (!(*paths)[*count].display_path) {
+        free((*paths)[*count].open_path);
+        (*paths)[*count].open_path = NULL;
+        return -1;
+    }
+
+    (*count)++;
+    return 0;
+}
+
+static int parse_selected_paths_output(const unsigned char* output,
+                                       size_t output_len,
+                                       const char* repo_root,
+                                       const char* prefix,
+                                       SelectedPath** paths_out,
+                                       size_t* count_out) {
     SelectedPath* paths = NULL;
     size_t count = 0;
     size_t capacity = 0;
-    int status = -1;
-
-    *paths_out = NULL;
-    *count_out = 0;
-
-    errno = 0;
-    if (capture_git_line(".", "--show-toplevel", &repo_root) != 0) {
-        if (errno == ENOENT) {
-            fprintf(stderr, "Git file-selection modes require git to be installed\n");
-        } else {
-            fprintf(stderr, "Git file-selection modes require a Git repository\n");
-        }
-        goto cleanup;
-    }
-    if (capture_git_line(".", "--show-prefix", &prefix) != 0) {
-        goto cleanup;
-    }
-
-    size_t argc = 0;
-    args[argc++] = "git";
-    args[argc++] = "-C";
-    args[argc++] = repo_root;
-    args[argc++] = "diff";
-    if (mode == FILE_SELECTION_GIT_STAGED) {
-        args[argc++] = "--cached";
-    }
-    args[argc++] = "--name-only";
-    args[argc++] = diff_filter;
-    args[argc++] = "-z";
-    if (mode == FILE_SELECTION_GIT_DIFF) {
-        args[argc++] = diff_range;
-    }
-    if (prefix[0] != '\0') {
-        args[argc++] = "--";
-        args[argc++] = prefix;
-    }
-    args[argc] = NULL;
-    argv = args;
-
-    if (run_command_capture(argv, &output, &output_len, &exit_status, &exec_errno) != 0) {
-        perror("Error running git");
-        goto cleanup;
-    }
-    if (exec_errno != 0) {
-        errno = exec_errno;
-        perror("Error executing git");
-        goto cleanup;
-    }
-    if (!WIFEXITED(exit_status) || WEXITSTATUS(exit_status) != 0) {
-        fprintf(stderr, "git diff failed for the requested file-selection mode\n");
-        goto cleanup;
-    }
-
     size_t start = 0;
     size_t prefix_len = strlen(prefix);
     size_t repo_root_len = strlen(repo_root);
+
     while (start < output_len) {
         size_t end = start;
         while (end < output_len && output[end] != '\0') {
             end++;
         }
         if (end > start) {
-            size_t repo_rel_len = end - start;
             const char* repo_rel = (const char*)(output + start);
-            const char* display_rel = repo_rel;
-
-            if (prefix_len > 0 &&
-                strncmp(repo_rel, prefix, prefix_len) == 0) {
-                display_rel = repo_rel + prefix_len;
+            size_t repo_rel_len = end - start;
+            if (append_selected_path(&paths,
+                                     &count,
+                                     &capacity,
+                                     repo_root,
+                                     repo_root_len,
+                                     prefix,
+                                     prefix_len,
+                                     repo_rel,
+                                     repo_rel_len) != 0) {
+                free_selected_paths(paths, count);
+                return -1;
             }
-
-            if (count == capacity) {
-                size_t new_capacity = (capacity == 0) ? 16 : capacity * 2;
-                SelectedPath* new_paths = realloc(paths, new_capacity * sizeof(*paths));
-                if (!new_paths) {
-                    goto cleanup;
-                }
-                paths = new_paths;
-                capacity = new_capacity;
-            }
-
-            size_t open_path_len = repo_root_len + 1 + repo_rel_len;
-            paths[count].open_path = malloc(open_path_len + 1);
-            if (!paths[count].open_path) {
-                goto cleanup;
-            }
-            memcpy(paths[count].open_path, repo_root, repo_root_len);
-            paths[count].open_path[repo_root_len] = '/';
-            memcpy(paths[count].open_path + repo_root_len + 1, repo_rel, repo_rel_len);
-            paths[count].open_path[open_path_len] = '\0';
-
-            paths[count].display_path = strdup(display_rel);
-            if (!paths[count].display_path) {
-                free(paths[count].open_path);
-                paths[count].open_path = NULL;
-                goto cleanup;
-            }
-            count++;
         }
         start = end + 1;
     }
@@ -347,13 +336,112 @@ int collect_git_paths(FileSelectionMode mode,
 
     *paths_out = paths;
     *count_out = count;
+    return 0;
+}
+
+int collect_git_paths(FileSelectionMode mode,
+                      const char* diff_range,
+                      int quiet_probe,
+                      SelectedPath** paths_out,
+                      size_t* count_out,
+                      GitPathResult* result_out) {
+    char* repo_root = NULL;
+    char* prefix = NULL;
+    const char* diff_filter = "--diff-filter=AMR";
+    const char* args[13];
+    unsigned char* output = NULL;
+    size_t output_len = 0;
+    int exit_status = 0;
+    int exec_errno = 0;
+    SelectedPath* paths = NULL;
+    size_t parsed_count = 0;
+    GitProbeResult probe_result = GIT_PROBE_READY;
+    int status = -1;
+
+    *paths_out = NULL;
+    *count_out = 0;
+    if (result_out) {
+        *result_out = GIT_PATHS_FALLBACK;
+    }
+
+    errno = 0;
+    if (capture_git_line(".", "--show-toplevel", quiet_probe, &repo_root, &probe_result) != 0) {
+        if (quiet_probe && probe_result == GIT_PROBE_FALLBACK) {
+            status = 0;
+            goto cleanup;
+        }
+        if (errno == ENOENT) {
+            fprintf(stderr, "Git file-selection modes require git to be installed\n");
+        } else {
+            fprintf(stderr, "Git file-selection modes require a Git repository\n");
+        }
+        goto cleanup;
+    }
+    if (capture_git_line(".", "--show-prefix", quiet_probe, &prefix, &probe_result) != 0) {
+        if (quiet_probe && probe_result == GIT_PROBE_FALLBACK) {
+            status = 0;
+            goto cleanup;
+        }
+        goto cleanup;
+    }
+
+    size_t argc = 0;
+    args[argc++] = "git";
+    args[argc++] = "-C";
+    args[argc++] = repo_root;
+    args[argc++] = (mode == FILE_SELECTION_GIT_WORKTREE) ? "ls-files" : "diff";
+    if (mode == FILE_SELECTION_GIT_WORKTREE) {
+        args[argc++] = "--cached";
+        args[argc++] = "--others";
+        args[argc++] = "--exclude-standard";
+    } else {
+        if (mode == FILE_SELECTION_GIT_STAGED) {
+            args[argc++] = "--cached";
+        }
+        args[argc++] = "--name-only";
+        args[argc++] = diff_filter;
+        if (mode == FILE_SELECTION_GIT_DIFF) {
+            args[argc++] = diff_range;
+        }
+    }
+    args[argc++] = "-z";
+    if (prefix[0] != '\0') {
+        args[argc++] = "--";
+        args[argc++] = prefix;
+    }
+    args[argc] = NULL;
+
+    if (run_command_capture(args, &output, &output_len, &exit_status, &exec_errno) != 0) {
+        perror("Error running git");
+        goto cleanup;
+    }
+    if (exec_errno != 0) {
+        errno = exec_errno;
+        perror("Error executing git");
+        goto cleanup;
+    }
+    if (!WIFEXITED(exit_status) || WEXITSTATUS(exit_status) != 0) {
+        fprintf(stderr, "git %s failed for the requested file-selection mode\n",
+                (mode == FILE_SELECTION_GIT_WORKTREE) ? "ls-files" : "diff");
+        goto cleanup;
+    }
+
+    if (parse_selected_paths_output(output, output_len, repo_root, prefix, &paths, &parsed_count) != 0) {
+        goto cleanup;
+    }
+
+    *paths_out = paths;
+    *count_out = parsed_count;
     paths = NULL;
+    if (result_out) {
+        *result_out = GIT_PATHS_COLLECTED;
+    }
     status = 0;
 
 cleanup:
     free(output);
     free(repo_root);
     free(prefix);
-    free_selected_paths(paths, count);
+    free_selected_paths(paths, parsed_count);
     return status;
 }

--- a/git_paths.h
+++ b/git_paths.h
@@ -10,10 +10,17 @@ typedef struct {
     char* display_path;
 } SelectedPath;
 
+typedef enum {
+    GIT_PATHS_COLLECTED = 0,
+    GIT_PATHS_FALLBACK
+} GitPathResult;
+
 int collect_git_paths(FileSelectionMode mode,
                       const char* diff_range,
+                      int quiet_probe,
                       SelectedPath** paths_out,
-                      size_t* count_out);
+                      size_t* count_out,
+                      GitPathResult* result_out);
 void free_selected_paths(SelectedPath* paths, size_t count);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -44,12 +44,14 @@ static int parse_positive_size_value(const char* value,
 
 static void print_usage(const char* argv0) {
     printf("Usage: %s [OPTIONS]\n", argv0);
-    printf("Export codebase to markdown file.\n\n");
+    printf("Export codebase to markdown file.\n");
+    printf("Default mode uses Git's worktree view when available and falls back to a recursive filesystem walk.\n\n");
     printf("Options:\n");
     printf("  -V, --version       Show version information\n");
     printf("  -v, --verbose       Show progress information\n");
     printf("  -s <size_kb>        Set maximum file size limit in KB (default: 100)\n");
     printf("  -o, --output        Set output path (use '-' for stdout)\n");
+    printf("      --no-git        Force recursive filesystem selection instead of auto Git detection\n");
     printf("      --staged        Export staged files from the current Git subtree\n");
     printf("      --unstaged      Export unstaged tracked files from the current Git subtree\n");
     printf("      --diff <r>      Export files changed by a git diff range (for example main...HEAD)\n");
@@ -158,10 +160,12 @@ static int make_temp_output_template(const char* output_path, char* tmpl, size_t
 
 int main(int argc, char* argv[]) {
     AppContext ctx = {0};
-    FileSelectionMode selection_mode = FILE_SELECTION_RECURSIVE;
+    FileSelectionMode requested_mode = FILE_SELECTION_AUTO;
+    FileSelectionMode resolved_mode = FILE_SELECTION_RECURSIVE;
     const char* diff_range = NULL;
     SelectedPath* selected_paths = NULL;
     size_t selected_count = 0;
+    GitPathResult git_result = GIT_PATHS_FALLBACK;
     ExportPlan plan = {0};
     ExportMetrics metrics = {0};
     int status = 1;
@@ -169,6 +173,7 @@ int main(int argc, char* argv[]) {
     int output_needs_close = 0;
     FILE* output_file = NULL;
     char temp_output_path[MAX_PATH_LENGTH];
+    int force_no_git = 0;
 
     ctx.max_file_size = MAX_FILE_SIZE;
     ctx.show_tree = 1;
@@ -215,6 +220,8 @@ int main(int argc, char* argv[]) {
                 return 1;
             }
             ctx.output_is_stdout = (strcmp(ctx.output_path, "-") == 0);
+        } else if (strcmp(argv[i], "--no-git") == 0) {
+            force_no_git = 1;
         } else if (strcmp(argv[i], "--no-clobber") == 0) {
             ctx.no_clobber = 1;
         } else if (strcmp(argv[i], "--tree") == 0) {
@@ -264,21 +271,21 @@ int main(int argc, char* argv[]) {
                 return 1;
             }
         } else if (strcmp(argv[i], "--staged") == 0) {
-            if (selection_mode != FILE_SELECTION_RECURSIVE) {
+            if (requested_mode != FILE_SELECTION_AUTO) {
                 fprintf(stderr, "File-selection flags are mutually exclusive\n");
                 fprintf(stderr, "Use -h or --help for usage information\n");
                 return 1;
             }
-            selection_mode = FILE_SELECTION_GIT_STAGED;
+            requested_mode = FILE_SELECTION_GIT_STAGED;
         } else if (strcmp(argv[i], "--unstaged") == 0) {
-            if (selection_mode != FILE_SELECTION_RECURSIVE) {
+            if (requested_mode != FILE_SELECTION_AUTO) {
                 fprintf(stderr, "File-selection flags are mutually exclusive\n");
                 fprintf(stderr, "Use -h or --help for usage information\n");
                 return 1;
             }
-            selection_mode = FILE_SELECTION_GIT_UNSTAGED;
+            requested_mode = FILE_SELECTION_GIT_UNSTAGED;
         } else if (strcmp(argv[i], "--diff") == 0) {
-            if (selection_mode != FILE_SELECTION_RECURSIVE) {
+            if (requested_mode != FILE_SELECTION_AUTO) {
                 fprintf(stderr, "File-selection flags are mutually exclusive\n");
                 fprintf(stderr, "Use -h or --help for usage information\n");
                 return 1;
@@ -293,9 +300,9 @@ int main(int argc, char* argv[]) {
                 fprintf(stderr, "Invalid diff range: empty string\n");
                 return 1;
             }
-            selection_mode = FILE_SELECTION_GIT_DIFF;
+            requested_mode = FILE_SELECTION_GIT_DIFF;
         } else if (strncmp(argv[i], "--diff=", 7) == 0) {
-            if (selection_mode != FILE_SELECTION_RECURSIVE) {
+            if (requested_mode != FILE_SELECTION_AUTO) {
                 fprintf(stderr, "File-selection flags are mutually exclusive\n");
                 fprintf(stderr, "Use -h or --help for usage information\n");
                 return 1;
@@ -305,7 +312,7 @@ int main(int argc, char* argv[]) {
                 fprintf(stderr, "Invalid diff range: empty string\n");
                 return 1;
             }
-            selection_mode = FILE_SELECTION_GIT_DIFF;
+            requested_mode = FILE_SELECTION_GIT_DIFF;
         } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
             print_usage(argv[0]);
             return 0;
@@ -316,13 +323,43 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (load_ignore_patterns(IGNORE_FILE, &ctx.ignore_patterns, &ctx.ignore_count) != 0) {
-        fprintf(stderr, "Error: Failed to initialize ignore patterns.\n");
+    if (force_no_git && requested_mode != FILE_SELECTION_AUTO) {
+        fprintf(stderr, "--no-git cannot be combined with --staged, --unstaged, or --diff\n");
+        fprintf(stderr, "Use -h or --help for usage information\n");
         return 1;
     }
 
-    if (selection_mode != FILE_SELECTION_RECURSIVE) {
-        if (collect_git_paths(selection_mode, diff_range, &selected_paths, &selected_count) != 0) {
+    if (force_no_git) {
+        requested_mode = FILE_SELECTION_RECURSIVE;
+    }
+
+    if (requested_mode == FILE_SELECTION_AUTO) {
+        if (collect_git_paths(FILE_SELECTION_GIT_WORKTREE,
+                              NULL,
+                              1,
+                              &selected_paths,
+                              &selected_count,
+                              &git_result) != 0) {
+            goto cleanup;
+        }
+        resolved_mode = (git_result == GIT_PATHS_COLLECTED) ? FILE_SELECTION_GIT_WORKTREE
+                                                            : FILE_SELECTION_RECURSIVE;
+    } else {
+        resolved_mode = requested_mode;
+    }
+
+    if (resolved_mode == FILE_SELECTION_RECURSIVE) {
+        if (load_ignore_patterns(IGNORE_FILE, &ctx.ignore_patterns, &ctx.ignore_count) != 0) {
+            fprintf(stderr, "Error: Failed to initialize ignore patterns.\n");
+            return 1;
+        }
+    } else if (resolved_mode != FILE_SELECTION_GIT_WORKTREE) {
+        if (collect_git_paths(resolved_mode,
+                              diff_range,
+                              0,
+                              &selected_paths,
+                              &selected_count,
+                              &git_result) != 0) {
             goto cleanup;
         }
     }
@@ -346,7 +383,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (selection_mode == FILE_SELECTION_RECURSIVE) {
+    if (resolved_mode == FILE_SELECTION_RECURSIVE) {
         if (collect_recursive_export_plan(&ctx, &plan) != 0) {
             fprintf(stderr, "Error collecting directory entries\n");
             goto cleanup;
@@ -358,7 +395,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (calculate_export_metrics(&plan, selection_mode, ctx.show_tree, ctx.tree_depth, &metrics) != 0) {
+    if (calculate_export_metrics(&plan, resolved_mode, ctx.show_tree, ctx.tree_depth, &metrics) != 0) {
         perror("Error calculating export metrics");
         goto cleanup;
     }
@@ -430,7 +467,7 @@ int main(int argc, char* argv[]) {
         ctx.have_temp = 1;
     }
 
-    if (write_export_header(output_file, selection_mode) != 0) {
+    if (write_export_header(output_file, resolved_mode) != 0) {
         perror("Error writing output header");
         goto cleanup;
     }

--- a/render.c
+++ b/render.c
@@ -29,6 +29,8 @@ static int add_size(size_t* total, size_t amount) {
 
 static const char* export_description(FileSelectionMode mode) {
     switch (mode) {
+        case FILE_SELECTION_GIT_WORKTREE:
+            return "This document contains tracked files plus untracked, non-ignored files from the current Git subtree.\n\n";
         case FILE_SELECTION_GIT_STAGED:
             return "This document contains staged files selected from the current Git subtree.\n\n";
         case FILE_SELECTION_GIT_UNSTAGED:
@@ -36,6 +38,8 @@ static const char* export_description(FileSelectionMode mode) {
         case FILE_SELECTION_GIT_DIFF:
             return "This document contains files selected from the current Git subtree by the requested Git diff range.\n\n";
         case FILE_SELECTION_RECURSIVE:
+            return "This document contains all the source code files from the current directory subtree using the local filesystem walker.\n\n";
+        case FILE_SELECTION_AUTO:
         default:
             return "This document contains all the source code files from the current directory subtree.\n\n";
     }

--- a/test_cli.sh
+++ b/test_cli.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+set -eu
+
+BIN=${BIN:-./fuori}
+BIN_DIR=$(cd "$(dirname "$BIN")" && pwd)
+BIN="$BIN_DIR/$(basename "$BIN")"
+
+fail() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+assert_contains() {
+    file=$1
+    pattern=$2
+    if ! grep -F -- "$pattern" "$file" >/dev/null 2>&1; then
+        fail "expected '$pattern' in $file"
+    fi
+}
+
+assert_not_contains() {
+    file=$1
+    pattern=$2
+    if grep -F -- "$pattern" "$file" >/dev/null 2>&1; then
+        fail "did not expect '$pattern' in $file"
+    fi
+}
+
+TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/fuori-cli-test.XXXXXX")
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+OUTSIDE="$TMPDIR/outside"
+mkdir -p "$OUTSIDE"
+cat >"$OUTSIDE/main.c" <<'EOF_OUTSIDE'
+int main(void) { return 0; }
+EOF_OUTSIDE
+
+(cd "$OUTSIDE" && "$BIN" -o - >stdout.txt 2>stderr.txt)
+assert_contains "$OUTSIDE/stdout.txt" "This document contains all the source code files from the current directory subtree using the local filesystem walker."
+assert_not_contains "$OUTSIDE/stderr.txt" "Git file-selection modes require"
+assert_not_contains "$OUTSIDE/stderr.txt" "git rev-parse failed"
+
+REPO="$TMPDIR/repo"
+mkdir -p "$REPO/sub"
+(cd "$REPO" && git init -q)
+cat >"$REPO/.gitignore" <<'EOF_IGNORE'
+ignored.log
+EOF_IGNORE
+cat >"$REPO/sub/tracked.c" <<'EOF_TRACKED'
+int tracked(void) { return 1; }
+EOF_TRACKED
+(cd "$REPO" && git add .gitignore sub/tracked.c && \
+    git -c user.name='fuori tests' -c user.email='fuori@example.com' commit -qm init)
+cat >"$REPO/sub/untracked.py" <<'EOF_UNTRACKED'
+print("hello")
+EOF_UNTRACKED
+cat >"$REPO/sub/ignored.log" <<'EOF_IGNORED'
+ignore me
+EOF_IGNORED
+
+(cd "$REPO/sub" && "$BIN" -o - >stdout.txt 2>stderr.txt)
+assert_contains "$REPO/sub/stdout.txt" "This document contains tracked files plus untracked, non-ignored files from the current Git subtree."
+assert_contains "$REPO/sub/stdout.txt" "├── tracked.c"
+assert_contains "$REPO/sub/stdout.txt" "└── untracked.py"
+assert_not_contains "$REPO/sub/stdout.txt" "ignored.log"
+assert_not_contains "$REPO/sub/stdout.txt" ".gitignore"
+
+(cd "$REPO" && "$BIN" --no-git -o - >stdout_no_git.txt 2>stderr_no_git.txt)
+assert_contains "$REPO/stdout_no_git.txt" "This document contains all the source code files from the current directory subtree using the local filesystem walker."
+
+if (cd "$REPO" && "$BIN" --no-git --staged >/dev/null 2>stderr_invalid.txt); then
+    fail "expected --no-git --staged to fail"
+fi
+assert_contains "$REPO/stderr_invalid.txt" "--no-git cannot be combined with --staged, --unstaged, or --diff"
+
+printf 'cli tests passed\n'


### PR DESCRIPTION
This changes the default export behavior to prefer Git’s view of the current subtree when available, while preserving the existing recursive filesystem walker as a silent fallback. Running fuori with no file-selection flags now uses git ls-files --cached --others --exclude-standard inside Git repositories, scoped to the current subdirectory when applicable, and falls back to the local walker outside repositories or when Git is unavailable. A new --no-git flag forces the filesystem walker, and invalid combinations like --no-git --staged are rejected.

Internally, the change separates requested selection mode from resolved mode so rendering, collection, and ignore loading reflect what actually happened. Git-backed modes now skip loading the custom ignore engine, while recursive mode retains the existing local .gitignore support.