### PR TITLE
refactor CLI and renderer flow, add export safety coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CPPFLAGS += -DVERSION=\"$(VERSION)\"
 CFLAGS = -Wall -Wextra -Wshadow -Wcast-align -Wwrite-strings -Wredundant-decls \
          -Wstrict-prototypes -Wold-style-definition -std=c99 -O2 -D_POSIX_C_SOURCE=200809L
 TARGET = fuori
-SOURCES = main.c collect.c render.c git_paths.c ignore.c
+SOURCES = main.c collect.c render.c git_paths.c ignore.c options.c tree.c
 TEST_TARGET = test_ignore
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin

--- a/main.c
+++ b/main.c
@@ -9,62 +9,14 @@
 
 #include "app.h"
 #include "collect.h"
-#include "git_paths.h"
 #include "ignore.h"
+#include "options.h"
 #include "render.h"
+#include "tree.h"
 
 #ifndef VERSION
 #define VERSION "dev"
 #endif
-
-static int parse_positive_size_value(const char* value,
-                                     const char* label,
-                                     size_t max_value,
-                                     size_t* out) {
-    char* endptr;
-    unsigned long long parsed;
-
-    if (!value || !out) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    errno = 0;
-    parsed = strtoull(value, &endptr, 10);
-    if (*value == '\0' || *endptr != '\0' || parsed == 0 ||
-        errno == ERANGE || parsed > max_value) {
-        fprintf(stderr, "Invalid %s value: %s\n", label, value);
-        fprintf(stderr, "Use -h or --help for usage information\n");
-        return -1;
-    }
-
-    *out = (size_t)parsed;
-    return 0;
-}
-
-static void print_usage(const char* argv0) {
-    printf("Usage: %s [OPTIONS]\n", argv0);
-    printf("Export codebase to markdown file.\n");
-    printf("Default mode uses Git's worktree view when available and falls back to a recursive filesystem walk.\n\n");
-    printf("Options:\n");
-    printf("  -V, --version       Show version information\n");
-    printf("  -v, --verbose       Show progress information\n");
-    printf("  -s <size_kb>        Set maximum file size limit in KB (default: 100)\n");
-    printf("  -o, --output        Set output path (use '-' for stdout)\n");
-    printf("      --no-git        Force recursive filesystem selection instead of auto Git detection\n");
-    printf("      --staged        Export staged files from the current Git subtree\n");
-    printf("      --unstaged      Export unstaged tracked files from the current Git subtree\n");
-    printf("      --diff <r>      Export files changed by a git diff range (for example main...HEAD)\n");
-    printf("                      Git file-selection flags are mutually exclusive\n");
-    printf("      --tree          Include a directory tree section (default)\n");
-    printf("      --no-tree       Omit the directory tree section\n");
-    printf("      --tree-depth    Limit tree rendering depth to N levels\n");
-    printf("      --warn-tokens   Warn if estimated tokens exceed N (default: %d)\n",
-           DEFAULT_WARN_TOKENS);
-    printf("      --max-tokens    Fail if estimated tokens exceed N\n");
-    printf("      --no-clobber    Fail if output file already exists\n");
-    printf("  -h, --help          Show this help message\n");
-}
 
 static int format_size_with_commas(size_t value, char* buffer, size_t buffer_size) {
     char reversed[64];
@@ -159,208 +111,48 @@ static int make_temp_output_template(const char* output_path, char* tmpl, size_t
 }
 
 int main(int argc, char* argv[]) {
+    CliOptions options;
     AppContext ctx = {0};
-    FileSelectionMode requested_mode = FILE_SELECTION_AUTO;
-    FileSelectionMode resolved_mode = FILE_SELECTION_RECURSIVE;
-    const char* diff_range = NULL;
     SelectedPath* selected_paths = NULL;
     size_t selected_count = 0;
-    GitPathResult git_result = GIT_PATHS_FALLBACK;
     ExportPlan plan = {0};
+    RenderPlanInfo render_info = {0};
     ExportMetrics metrics = {0};
     int status = 1;
     int temp_created = 0;
     int output_needs_close = 0;
     FILE* output_file = NULL;
     char temp_output_path[MAX_PATH_LENGTH];
-    int force_no_git = 0;
-
-    ctx.max_file_size = MAX_FILE_SIZE;
-    ctx.show_tree = 1;
-    ctx.tree_depth = SIZE_MAX;
-    ctx.warn_tokens = DEFAULT_WARN_TOKENS;
-    ctx.output_path = DEFAULT_OUTPUT_FILE;
     temp_output_path[0] = '\0';
-
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-V") == 0 || strcmp(argv[i], "--version") == 0) {
-            printf("fuori %s\n", VERSION);
-            return 0;
-        } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
-            ctx.verbose = 1;
-        } else if (strcmp(argv[i], "-s") == 0) {
-            if (i + 1 < argc) {
-                size_t size_kb;
-                if (parse_positive_size_value(argv[++i], "size", SIZE_MAX / 1024ULL, &size_kb) != 0) {
-                    return 1;
-                }
-                ctx.max_file_size = size_kb * 1024ULL;
-            } else {
-                fprintf(stderr, "Missing size value for -s option\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-        } else if (strcmp(argv[i], "-o") == 0 || strcmp(argv[i], "--output") == 0) {
-            if (i + 1 < argc) {
-                ctx.output_path = argv[++i];
-                if (ctx.output_path[0] == '\0') {
-                    fprintf(stderr, "Invalid output path: empty string\n");
-                    return 1;
-                }
-                ctx.output_is_stdout = (strcmp(ctx.output_path, "-") == 0);
-            } else {
-                fprintf(stderr, "Missing path value for -o/--output option\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-        } else if (strncmp(argv[i], "--output=", 9) == 0) {
-            ctx.output_path = argv[i] + 9;
-            if (ctx.output_path[0] == '\0') {
-                fprintf(stderr, "Invalid output path: empty string\n");
-                return 1;
-            }
-            ctx.output_is_stdout = (strcmp(ctx.output_path, "-") == 0);
-        } else if (strcmp(argv[i], "--no-git") == 0) {
-            force_no_git = 1;
-        } else if (strcmp(argv[i], "--no-clobber") == 0) {
-            ctx.no_clobber = 1;
-        } else if (strcmp(argv[i], "--tree") == 0) {
-            ctx.show_tree = 1;
-        } else if (strcmp(argv[i], "--no-tree") == 0) {
-            ctx.show_tree = 0;
-        } else if (strcmp(argv[i], "--tree-depth") == 0) {
-            if (i + 1 < argc) {
-                if (parse_positive_size_value(argv[++i], "tree depth", SIZE_MAX, &ctx.tree_depth) != 0) {
-                    return 1;
-                }
-            } else {
-                fprintf(stderr, "Missing value for --tree-depth option\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-        } else if (strncmp(argv[i], "--tree-depth=", 13) == 0) {
-            if (parse_positive_size_value(argv[i] + 13, "tree depth", SIZE_MAX, &ctx.tree_depth) != 0) {
-                return 1;
-            }
-        } else if (strcmp(argv[i], "--warn-tokens") == 0) {
-            if (i + 1 < argc) {
-                if (parse_positive_size_value(argv[++i], "warn-tokens", SIZE_MAX, &ctx.warn_tokens) != 0) {
-                    return 1;
-                }
-            } else {
-                fprintf(stderr, "Missing value for --warn-tokens option\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-        } else if (strncmp(argv[i], "--warn-tokens=", 14) == 0) {
-            if (parse_positive_size_value(argv[i] + 14, "warn-tokens", SIZE_MAX, &ctx.warn_tokens) != 0) {
-                return 1;
-            }
-        } else if (strcmp(argv[i], "--max-tokens") == 0) {
-            if (i + 1 < argc) {
-                if (parse_positive_size_value(argv[++i], "max-tokens", SIZE_MAX, &ctx.max_tokens) != 0) {
-                    return 1;
-                }
-            } else {
-                fprintf(stderr, "Missing value for --max-tokens option\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-        } else if (strncmp(argv[i], "--max-tokens=", 13) == 0) {
-            if (parse_positive_size_value(argv[i] + 13, "max-tokens", SIZE_MAX, &ctx.max_tokens) != 0) {
-                return 1;
-            }
-        } else if (strcmp(argv[i], "--staged") == 0) {
-            if (requested_mode != FILE_SELECTION_AUTO) {
-                fprintf(stderr, "File-selection flags are mutually exclusive\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-            requested_mode = FILE_SELECTION_GIT_STAGED;
-        } else if (strcmp(argv[i], "--unstaged") == 0) {
-            if (requested_mode != FILE_SELECTION_AUTO) {
-                fprintf(stderr, "File-selection flags are mutually exclusive\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-            requested_mode = FILE_SELECTION_GIT_UNSTAGED;
-        } else if (strcmp(argv[i], "--diff") == 0) {
-            if (requested_mode != FILE_SELECTION_AUTO) {
-                fprintf(stderr, "File-selection flags are mutually exclusive\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-            if (i + 1 >= argc) {
-                fprintf(stderr, "Missing range value for --diff option\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-            diff_range = argv[++i];
-            if (diff_range[0] == '\0') {
-                fprintf(stderr, "Invalid diff range: empty string\n");
-                return 1;
-            }
-            requested_mode = FILE_SELECTION_GIT_DIFF;
-        } else if (strncmp(argv[i], "--diff=", 7) == 0) {
-            if (requested_mode != FILE_SELECTION_AUTO) {
-                fprintf(stderr, "File-selection flags are mutually exclusive\n");
-                fprintf(stderr, "Use -h or --help for usage information\n");
-                return 1;
-            }
-            diff_range = argv[i] + 7;
-            if (diff_range[0] == '\0') {
-                fprintf(stderr, "Invalid diff range: empty string\n");
-                return 1;
-            }
-            requested_mode = FILE_SELECTION_GIT_DIFF;
-        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
-            print_usage(argv[0]);
-            return 0;
-        } else {
-            fprintf(stderr, "Unknown option: %s\n", argv[i]);
-            fprintf(stderr, "Use -h or --help for usage information\n");
-            return 1;
-        }
-    }
-
-    if (force_no_git && requested_mode != FILE_SELECTION_AUTO) {
-        fprintf(stderr, "--no-git cannot be combined with --staged, --unstaged, or --diff\n");
-        fprintf(stderr, "Use -h or --help for usage information\n");
+    if (parse_cli_options(argc, argv, &options) != 0) {
         return 1;
     }
-
-    if (force_no_git) {
-        requested_mode = FILE_SELECTION_RECURSIVE;
+    if (options.show_version) {
+        printf("fuori %s\n", VERSION);
+        return 0;
+    }
+    if (options.show_help) {
+        print_usage(argv[0]);
+        return 0;
+    }
+    if (resolve_cli_selection(&options, &selected_paths, &selected_count) != 0) {
+        goto cleanup;
     }
 
-    if (requested_mode == FILE_SELECTION_AUTO) {
-        if (collect_git_paths(FILE_SELECTION_GIT_WORKTREE,
-                              NULL,
-                              1,
-                              &selected_paths,
-                              &selected_count,
-                              &git_result) != 0) {
-            goto cleanup;
-        }
-        resolved_mode = (git_result == GIT_PATHS_COLLECTED) ? FILE_SELECTION_GIT_WORKTREE
-                                                            : FILE_SELECTION_RECURSIVE;
-    } else {
-        resolved_mode = requested_mode;
-    }
+    ctx.verbose = options.verbose;
+    ctx.no_clobber = options.no_clobber;
+    ctx.output_is_stdout = options.output_is_stdout;
+    ctx.show_tree = options.show_tree;
+    ctx.max_file_size = options.max_file_size;
+    ctx.tree_depth = options.tree_depth;
+    ctx.warn_tokens = options.warn_tokens;
+    ctx.max_tokens = options.max_tokens;
+    ctx.output_path = options.output_path;
 
-    if (resolved_mode == FILE_SELECTION_RECURSIVE) {
+    if (options.resolved_mode == FILE_SELECTION_RECURSIVE) {
         if (load_ignore_patterns(IGNORE_FILE, &ctx.ignore_patterns, &ctx.ignore_count) != 0) {
             fprintf(stderr, "Error: Failed to initialize ignore patterns.\n");
             return 1;
-        }
-    } else if (resolved_mode != FILE_SELECTION_GIT_WORKTREE) {
-        if (collect_git_paths(resolved_mode,
-                              diff_range,
-                              0,
-                              &selected_paths,
-                              &selected_count,
-                              &git_result) != 0) {
-            goto cleanup;
         }
     }
 
@@ -383,7 +175,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (resolved_mode == FILE_SELECTION_RECURSIVE) {
+    if (options.resolved_mode == FILE_SELECTION_RECURSIVE) {
         if (collect_recursive_export_plan(&ctx, &plan) != 0) {
             fprintf(stderr, "Error collecting directory entries\n");
             goto cleanup;
@@ -395,7 +187,12 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (calculate_export_metrics(&plan, resolved_mode, ctx.show_tree, ctx.tree_depth, &metrics) != 0) {
+    if (prepare_render_plan(&plan, &render_info) != 0) {
+        perror("Error preparing render plan");
+        goto cleanup;
+    }
+
+    if (calculate_export_metrics(&plan, &render_info, options.resolved_mode, ctx.show_tree, ctx.tree_depth, &metrics) != 0) {
         perror("Error calculating export metrics");
         goto cleanup;
     }
@@ -467,7 +264,7 @@ int main(int argc, char* argv[]) {
         ctx.have_temp = 1;
     }
 
-    if (write_export_header(output_file, resolved_mode) != 0) {
+    if (write_export_header(output_file, options.resolved_mode) != 0) {
         perror("Error writing output header");
         goto cleanup;
     }
@@ -479,7 +276,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (render_export_plan(output_file, &plan, ctx.verbose) != 0) {
+    if (render_export_plan(output_file, &plan, &render_info, ctx.verbose) != 0) {
         fprintf(stderr, "Error processing export files\n");
         goto cleanup;
     }
@@ -521,6 +318,7 @@ cleanup:
         unlink(temp_output_path);
     }
     free_export_plan(&plan);
+    free_render_plan_info(&render_info);
     free_selected_paths(selected_paths, selected_count);
     free_ignore_patterns(ctx.ignore_patterns, ctx.ignore_count);
     return status;

--- a/options.c
+++ b/options.c
@@ -1,0 +1,275 @@
+#include "options.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int parse_positive_size_value(const char* value,
+                                     const char* label,
+                                     size_t max_value,
+                                     size_t* out) {
+    char* endptr;
+    unsigned long long parsed;
+
+    if (!value || !out) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    errno = 0;
+    parsed = strtoull(value, &endptr, 10);
+    if (*value == '\0' || *endptr != '\0' || parsed == 0 ||
+        errno == ERANGE || parsed > max_value) {
+        fprintf(stderr, "Invalid %s value: %s\n", label, value);
+        fprintf(stderr, "Use -h or --help for usage information\n");
+        return -1;
+    }
+
+    *out = (size_t)parsed;
+    return 0;
+}
+
+void init_cli_options(CliOptions* options) {
+    if (!options) {
+        return;
+    }
+
+    memset(options, 0, sizeof(*options));
+    options->max_file_size = MAX_FILE_SIZE;
+    options->show_tree = 1;
+    options->tree_depth = SIZE_MAX;
+    options->warn_tokens = DEFAULT_WARN_TOKENS;
+    options->output_path = DEFAULT_OUTPUT_FILE;
+    options->requested_mode = FILE_SELECTION_AUTO;
+    options->resolved_mode = FILE_SELECTION_RECURSIVE;
+}
+
+void print_usage(const char* argv0) {
+    printf("Usage: %s [OPTIONS]\n", argv0);
+    printf("Export codebase to markdown file.\n");
+    printf("Default mode uses Git's worktree view when available and falls back to a recursive filesystem walk.\n\n");
+    printf("Options:\n");
+    printf("  -V, --version       Show version information\n");
+    printf("  -v, --verbose       Show progress information\n");
+    printf("  -s <size_kb>        Set maximum file size limit in KB (default: 100)\n");
+    printf("  -o, --output        Set output path (use '-' for stdout)\n");
+    printf("      --no-git        Force recursive filesystem selection instead of auto Git detection\n");
+    printf("      --staged        Export staged files from the current Git subtree\n");
+    printf("      --unstaged      Export unstaged tracked files from the current Git subtree\n");
+    printf("      --diff <r>      Export files changed by a git diff range (for example main...HEAD)\n");
+    printf("                      Git file-selection flags are mutually exclusive\n");
+    printf("      --tree          Include a directory tree section (default)\n");
+    printf("      --no-tree       Omit the directory tree section\n");
+    printf("      --tree-depth    Limit tree rendering depth to N levels\n");
+    printf("      --warn-tokens   Warn if estimated tokens exceed N (default: %d)\n",
+           DEFAULT_WARN_TOKENS);
+    printf("      --max-tokens    Fail if estimated tokens exceed N\n");
+    printf("      --no-clobber    Fail if output file already exists\n");
+    printf("  -h, --help          Show this help message\n");
+}
+
+int parse_cli_options(int argc, char* argv[], CliOptions* options) {
+    int force_no_git = 0;
+
+    if (!options) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    init_cli_options(options);
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-V") == 0 || strcmp(argv[i], "--version") == 0) {
+            options->show_version = 1;
+            return 0;
+        } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
+            options->verbose = 1;
+        } else if (strcmp(argv[i], "-s") == 0) {
+            if (i + 1 < argc) {
+                size_t size_kb;
+                if (parse_positive_size_value(argv[++i], "size", SIZE_MAX / 1024ULL, &size_kb) != 0) {
+                    return -1;
+                }
+                options->max_file_size = size_kb * 1024ULL;
+            } else {
+                fprintf(stderr, "Missing size value for -s option\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+        } else if (strcmp(argv[i], "-o") == 0 || strcmp(argv[i], "--output") == 0) {
+            if (i + 1 < argc) {
+                options->output_path = argv[++i];
+                if (options->output_path[0] == '\0') {
+                    fprintf(stderr, "Invalid output path: empty string\n");
+                    return -1;
+                }
+                options->output_is_stdout = (strcmp(options->output_path, "-") == 0);
+            } else {
+                fprintf(stderr, "Missing path value for -o/--output option\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+        } else if (strncmp(argv[i], "--output=", 9) == 0) {
+            options->output_path = argv[i] + 9;
+            if (options->output_path[0] == '\0') {
+                fprintf(stderr, "Invalid output path: empty string\n");
+                return -1;
+            }
+            options->output_is_stdout = (strcmp(options->output_path, "-") == 0);
+        } else if (strcmp(argv[i], "--no-git") == 0) {
+            force_no_git = 1;
+        } else if (strcmp(argv[i], "--no-clobber") == 0) {
+            options->no_clobber = 1;
+        } else if (strcmp(argv[i], "--tree") == 0) {
+            options->show_tree = 1;
+        } else if (strcmp(argv[i], "--no-tree") == 0) {
+            options->show_tree = 0;
+        } else if (strcmp(argv[i], "--tree-depth") == 0) {
+            if (i + 1 < argc) {
+                if (parse_positive_size_value(argv[++i], "tree depth", SIZE_MAX, &options->tree_depth) != 0) {
+                    return -1;
+                }
+            } else {
+                fprintf(stderr, "Missing value for --tree-depth option\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+        } else if (strncmp(argv[i], "--tree-depth=", 13) == 0) {
+            if (parse_positive_size_value(argv[i] + 13, "tree depth", SIZE_MAX, &options->tree_depth) != 0) {
+                return -1;
+            }
+        } else if (strcmp(argv[i], "--warn-tokens") == 0) {
+            if (i + 1 < argc) {
+                if (parse_positive_size_value(argv[++i], "warn-tokens", SIZE_MAX, &options->warn_tokens) != 0) {
+                    return -1;
+                }
+            } else {
+                fprintf(stderr, "Missing value for --warn-tokens option\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+        } else if (strncmp(argv[i], "--warn-tokens=", 14) == 0) {
+            if (parse_positive_size_value(argv[i] + 14, "warn-tokens", SIZE_MAX, &options->warn_tokens) != 0) {
+                return -1;
+            }
+        } else if (strcmp(argv[i], "--max-tokens") == 0) {
+            if (i + 1 < argc) {
+                if (parse_positive_size_value(argv[++i], "max-tokens", SIZE_MAX, &options->max_tokens) != 0) {
+                    return -1;
+                }
+            } else {
+                fprintf(stderr, "Missing value for --max-tokens option\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+        } else if (strncmp(argv[i], "--max-tokens=", 13) == 0) {
+            if (parse_positive_size_value(argv[i] + 13, "max-tokens", SIZE_MAX, &options->max_tokens) != 0) {
+                return -1;
+            }
+        } else if (strcmp(argv[i], "--staged") == 0) {
+            if (options->requested_mode != FILE_SELECTION_AUTO) {
+                fprintf(stderr, "File-selection flags are mutually exclusive\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+            options->requested_mode = FILE_SELECTION_GIT_STAGED;
+        } else if (strcmp(argv[i], "--unstaged") == 0) {
+            if (options->requested_mode != FILE_SELECTION_AUTO) {
+                fprintf(stderr, "File-selection flags are mutually exclusive\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+            options->requested_mode = FILE_SELECTION_GIT_UNSTAGED;
+        } else if (strcmp(argv[i], "--diff") == 0) {
+            if (options->requested_mode != FILE_SELECTION_AUTO) {
+                fprintf(stderr, "File-selection flags are mutually exclusive\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+            if (i + 1 >= argc) {
+                fprintf(stderr, "Missing range value for --diff option\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+            options->diff_range = argv[++i];
+            if (options->diff_range[0] == '\0') {
+                fprintf(stderr, "Invalid diff range: empty string\n");
+                return -1;
+            }
+            options->requested_mode = FILE_SELECTION_GIT_DIFF;
+        } else if (strncmp(argv[i], "--diff=", 7) == 0) {
+            if (options->requested_mode != FILE_SELECTION_AUTO) {
+                fprintf(stderr, "File-selection flags are mutually exclusive\n");
+                fprintf(stderr, "Use -h or --help for usage information\n");
+                return -1;
+            }
+            options->diff_range = argv[i] + 7;
+            if (options->diff_range[0] == '\0') {
+                fprintf(stderr, "Invalid diff range: empty string\n");
+                return -1;
+            }
+            options->requested_mode = FILE_SELECTION_GIT_DIFF;
+        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            options->show_help = 1;
+            return 0;
+        } else {
+            fprintf(stderr, "Unknown option: %s\n", argv[i]);
+            fprintf(stderr, "Use -h or --help for usage information\n");
+            return -1;
+        }
+    }
+
+    if (force_no_git && options->requested_mode != FILE_SELECTION_AUTO) {
+        fprintf(stderr, "--no-git cannot be combined with --staged, --unstaged, or --diff\n");
+        fprintf(stderr, "Use -h or --help for usage information\n");
+        return -1;
+    }
+
+    if (force_no_git) {
+        options->requested_mode = FILE_SELECTION_RECURSIVE;
+    }
+
+    return 0;
+}
+
+int resolve_cli_selection(CliOptions* options,
+                          SelectedPath** selected_paths_out,
+                          size_t* selected_count_out) {
+    GitPathResult git_result = GIT_PATHS_FALLBACK;
+
+    if (!options || !selected_paths_out || !selected_count_out) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *selected_paths_out = NULL;
+    *selected_count_out = 0;
+
+    if (options->requested_mode == FILE_SELECTION_AUTO) {
+        if (collect_git_paths(FILE_SELECTION_GIT_WORKTREE,
+                              NULL,
+                              1,
+                              selected_paths_out,
+                              selected_count_out,
+                              &git_result) != 0) {
+            return -1;
+        }
+        options->resolved_mode = (git_result == GIT_PATHS_COLLECTED) ? FILE_SELECTION_GIT_WORKTREE
+                                                                     : FILE_SELECTION_RECURSIVE;
+        return 0;
+    }
+
+    options->resolved_mode = options->requested_mode;
+    if (options->resolved_mode == FILE_SELECTION_RECURSIVE) {
+        return 0;
+    }
+
+    return collect_git_paths(options->resolved_mode,
+                             options->diff_range,
+                             0,
+                             selected_paths_out,
+                             selected_count_out,
+                             &git_result);
+}

--- a/options.h
+++ b/options.h
@@ -1,0 +1,31 @@
+#ifndef OPTIONS_H
+#define OPTIONS_H
+
+#include "app.h"
+#include "git_paths.h"
+
+typedef struct {
+    int show_help;
+    int show_version;
+    int verbose;
+    int no_clobber;
+    int output_is_stdout;
+    int show_tree;
+    size_t max_file_size;
+    size_t tree_depth;
+    size_t warn_tokens;
+    size_t max_tokens;
+    const char* output_path;
+    const char* diff_range;
+    FileSelectionMode requested_mode;
+    FileSelectionMode resolved_mode;
+} CliOptions;
+
+void init_cli_options(CliOptions* options);
+void print_usage(const char* argv0);
+int parse_cli_options(int argc, char* argv[], CliOptions* options);
+int resolve_cli_selection(CliOptions* options,
+                          SelectedPath** selected_paths_out,
+                          size_t* selected_count_out);
+
+#endif

--- a/render.c
+++ b/render.c
@@ -5,18 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define TREE_BRANCH "\xE2\x94\x9C\xE2\x94\x80\xE2\x94\x80 "
-#define TREE_LAST "\xE2\x94\x94\xE2\x94\x80\xE2\x94\x80 "
-#define TREE_PIPE "\xE2\x94\x82   "
-#define TREE_SPACE "    "
-
-typedef struct TreeNode {
-    char* name;
-    int is_dir;
-    struct TreeNode** children;
-    size_t child_count;
-    size_t child_capacity;
-} TreeNode;
+#include "tree.h"
 
 static int add_size(size_t* total, size_t amount) {
     if (*total > SIZE_MAX - amount) {
@@ -55,36 +44,6 @@ static int write_text(FILE* out, const char* text) {
 
 static int write_bytes(FILE* out, const void* data, size_t len) {
     return (fwrite(data, 1, len, out) == len) ? 0 : -1;
-}
-
-static int write_visible_text(FILE* out, const char* text) {
-    for (const unsigned char* p = (const unsigned char*)text; *p != '\0'; p++) {
-        unsigned char c = *p;
-        if (c == '\n') {
-            if (write_text(out, "\\n") != 0) return -1;
-            continue;
-        }
-        if (c == '\r') {
-            if (write_text(out, "\\r") != 0) return -1;
-            continue;
-        }
-        if (c == '\t') {
-            if (write_text(out, "\\t") != 0) return -1;
-            continue;
-        }
-        if ((c < 0x20 || c == 0x7f)) {
-            char escaped[5];
-            if (snprintf(escaped, sizeof(escaped), "\\x%02X", c) < 0 ||
-                write_text(out, escaped) != 0) {
-                return -1;
-            }
-            continue;
-        }
-        if (fputc(c, out) == EOF) {
-            return -1;
-        }
-    }
-    return 0;
 }
 
 static int write_markdown_path(FILE* out, const char* path) {
@@ -132,22 +91,6 @@ static int write_markdown_path(FILE* out, const char* path) {
 
 static int count_text_bytes(size_t* total, const char* text) {
     return add_size(total, strlen(text));
-}
-
-static int count_visible_text_bytes(size_t* total, const char* text) {
-    for (const unsigned char* p = (const unsigned char*)text; *p != '\0'; p++) {
-        unsigned char c = *p;
-        if (c == '\n' || c == '\r' || c == '\t') {
-            if (add_size(total, 2) != 0) return -1;
-            continue;
-        }
-        if ((c < 0x20 || c == 0x7f)) {
-            if (add_size(total, 4) != 0) return -1;
-            continue;
-        }
-        if (add_size(total, 1) != 0) return -1;
-    }
-    return 0;
 }
 
 static int count_markdown_path_bytes(size_t* total, const char* path) {
@@ -202,257 +145,71 @@ int write_export_header(FILE* out, FileSelectionMode mode) {
     return write_text(out, export_description(mode));
 }
 
-static TreeNode* tree_node_create(const char* name, int is_dir) {
-    TreeNode* node = calloc(1, sizeof(*node));
-    if (!node) {
-        return NULL;
-    }
-
-    node->name = strdup(name ? name : "");
-    if (!node->name) {
-        free(node);
-        return NULL;
-    }
-    node->is_dir = is_dir;
-    return node;
-}
-
-static void free_tree(TreeNode* node) {
-    if (!node) return;
-    for (size_t i = 0; i < node->child_count; i++) {
-        free_tree(node->children[i]);
-    }
-    free(node->children);
-    free(node->name);
-    free(node);
-}
-
-static int compare_tree_nodes(const void* lhs, const void* rhs) {
-    const TreeNode* const* left = lhs;
-    const TreeNode* const* right = rhs;
-    if ((*left)->is_dir != (*right)->is_dir) {
-        return (*right)->is_dir - (*left)->is_dir;
-    }
-    return strcmp((*left)->name, (*right)->name);
-}
-
-static int tree_add_path(TreeNode* root, const char* display_path) {
-    char* path_copy = strdup(display_path);
-    if (!path_copy) {
-        return -1;
-    }
-
-    TreeNode* current = root;
-    char* saveptr = NULL;
-    char* token = strtok_r(path_copy, "/", &saveptr);
-    while (token) {
-        char* next = strtok_r(NULL, "/", &saveptr);
-        int is_dir = (next != NULL);
-        TreeNode* child = NULL;
-
-        for (size_t i = 0; i < current->child_count; i++) {
-            if (strcmp(current->children[i]->name, token) == 0) {
-                child = current->children[i];
-                break;
-            }
-        }
-
-        if (!child) {
-            if (current->child_count == current->child_capacity) {
-                size_t new_capacity = (current->child_capacity == 0) ? 8 : current->child_capacity * 2;
-                TreeNode** new_children = realloc(current->children, new_capacity * sizeof(*new_children));
-                if (!new_children) {
-                    free(path_copy);
-                    return -1;
-                }
-                current->children = new_children;
-                current->child_capacity = new_capacity;
-            }
-
-            child = tree_node_create(token, is_dir);
-            if (!child) {
-                free(path_copy);
-                return -1;
-            }
-            current->children[current->child_count++] = child;
-        } else if (is_dir) {
-            child->is_dir = 1;
-        }
-
-        current = child;
-        token = next;
-    }
-
-    free(path_copy);
-    return 0;
-}
-
-static void sort_tree(TreeNode* node) {
-    if (!node) return;
-    if (node->child_count > 1) {
-        qsort(node->children, node->child_count, sizeof(*node->children), compare_tree_nodes);
-    }
-    for (size_t i = 0; i < node->child_count; i++) {
-        sort_tree(node->children[i]);
-    }
-}
-
-static int write_tree_children(FILE* out,
-                               const TreeNode* node,
-                               const char* prefix,
-                               size_t depth,
-                               size_t max_depth) {
-    for (size_t i = 0; i < node->child_count; i++) {
-        const TreeNode* child = node->children[i];
-        int is_last = (i + 1 == node->child_count);
-
-        if (write_text(out, prefix) != 0 ||
-            write_text(out, is_last ? TREE_LAST : TREE_BRANCH) != 0 ||
-            write_visible_text(out, child->name) != 0 ||
-            write_text(out, "\n") != 0) {
-            return -1;
-        }
-
-        if (child->is_dir &&
-            child->child_count > 0 &&
-            (max_depth == SIZE_MAX || depth < max_depth)) {
-            const char* segment = is_last ? TREE_SPACE : TREE_PIPE;
-            size_t prefix_len = strlen(prefix);
-            size_t segment_len = strlen(segment);
-            char* next_prefix = malloc(prefix_len + segment_len + 1);
-            if (!next_prefix) {
-                return -1;
-            }
-            memcpy(next_prefix, prefix, prefix_len);
-            memcpy(next_prefix + prefix_len, segment, segment_len + 1);
-
-            int result = write_tree_children(out, child, next_prefix, depth + 1, max_depth);
-            free(next_prefix);
-            if (result != 0) {
-                return -1;
-            }
-        }
-    }
-
-    return 0;
-}
-
-static int count_tree_children_bytes(const TreeNode* node,
-                                     size_t prefix_len,
-                                     size_t depth,
-                                     size_t max_depth,
-                                     size_t* total) {
-    for (size_t i = 0; i < node->child_count; i++) {
-        const TreeNode* child = node->children[i];
-        int is_last = (i + 1 == node->child_count);
-        const char* branch = is_last ? TREE_LAST : TREE_BRANCH;
-
-        if (add_size(total, prefix_len) != 0 ||
-            add_size(total, strlen(branch)) != 0 ||
-            count_visible_text_bytes(total, child->name) != 0 ||
-            add_size(total, 1) != 0) {
-            return -1;
-        }
-
-        if (child->is_dir &&
-            child->child_count > 0 &&
-            (max_depth == SIZE_MAX || depth < max_depth)) {
-            const char* segment = is_last ? TREE_SPACE : TREE_PIPE;
-            size_t next_prefix_len = prefix_len + strlen(segment);
-            if (next_prefix_len < prefix_len) {
-                errno = EOVERFLOW;
-                return -1;
-            }
-            if (count_tree_children_bytes(child, next_prefix_len, depth + 1, max_depth, total) != 0) {
-                return -1;
-            }
-        }
-    }
-
-    return 0;
-}
-
-int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
-    TreeNode* root = tree_node_create("", 1);
-    if (!root) {
-        return -1;
-    }
-
-    for (size_t i = 0; i < plan->count; i++) {
-        if (tree_add_path(root, plan->entries[i].display_path) != 0) {
-            free_tree(root);
-            return -1;
-        }
-    }
-    sort_tree(root);
-
-    if (write_text(out, "## Project Tree\n\n```text\n") != 0) {
-        free_tree(root);
-        return -1;
-    }
-
-    if (root->child_count == 0) {
-        if (write_text(out, "(no exported files)\n") != 0) {
-            free_tree(root);
-            return -1;
-        }
-    } else if (write_tree_children(out, root, "", 1, max_depth) != 0) {
-        free_tree(root);
-        return -1;
-    }
-
-    free_tree(root);
-    return write_text(out, "```\n\n");
-}
-
-static int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total) {
-    TreeNode* root = tree_node_create("", 1);
-    if (!root) {
-        return -1;
-    }
-
-    for (size_t i = 0; i < plan->count; i++) {
-        if (tree_add_path(root, plan->entries[i].display_path) != 0) {
-            free_tree(root);
-            return -1;
-        }
-    }
-    sort_tree(root);
-
-    if (count_text_bytes(total, "## Project Tree\n\n```text\n") != 0) {
-        free_tree(root);
-        return -1;
-    }
-
-    if (root->child_count == 0) {
-        if (count_text_bytes(total, "(no exported files)\n") != 0) {
-            free_tree(root);
-            return -1;
-        }
-    } else if (count_tree_children_bytes(root, 0, 1, max_depth, total) != 0) {
-        free_tree(root);
-        return -1;
-    }
-
-    free_tree(root);
-    return count_text_bytes(total, "```\n\n");
-}
-
-static int count_entry_bytes(const ExportEntry* entry, size_t* total) {
+static size_t compute_fence_length(const ExportEntry* entry) {
     size_t max_run = 0;
     size_t current_run = 0;
-    size_t fence = 3;
 
     for (size_t i = 0; i < entry->buf_len; i++) {
         if (entry->buf[i] == '`') {
             current_run++;
-            if (current_run > max_run) max_run = current_run;
+            if (current_run > max_run) {
+                max_run = current_run;
+            }
         } else {
             current_run = 0;
         }
     }
-    fence = (max_run >= 3 ? max_run + 1 : 3);
 
+    return (max_run >= 3) ? max_run + 1 : 3;
+}
+
+int prepare_render_plan(const ExportPlan* plan, RenderPlanInfo* info) {
+    if (!plan || !info) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    info->fence_lengths = NULL;
+    info->count = 0;
+
+    if (plan->count == 0) {
+        return 0;
+    }
+
+    info->fence_lengths = malloc(plan->count * sizeof(*info->fence_lengths));
+    if (!info->fence_lengths) {
+        return -1;
+    }
+
+    info->count = plan->count;
+    for (size_t i = 0; i < plan->count; i++) {
+        info->fence_lengths[i] = compute_fence_length(&plan->entries[i]);
+    }
+
+    return 0;
+}
+
+void free_render_plan_info(RenderPlanInfo* info) {
+    if (!info) {
+        return;
+    }
+
+    free(info->fence_lengths);
+    info->fence_lengths = NULL;
+    info->count = 0;
+}
+
+static int get_fence_length(const RenderPlanInfo* info, size_t index, size_t* fence_out) {
+    if (!info || !fence_out || index >= info->count) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *fence_out = info->fence_lengths[index];
+    return 0;
+}
+
+static int count_entry_bytes(const ExportEntry* entry, size_t fence, size_t* total) {
     if (count_text_bytes(total, "## ") != 0 ||
         count_markdown_path_bytes(total, entry->display_path) != 0 ||
         count_text_bytes(total, "\n\n") != 0 ||
@@ -472,13 +229,14 @@ static int count_entry_bytes(const ExportEntry* entry, size_t* total) {
 }
 
 int calculate_export_metrics(const ExportPlan* plan,
+                             const RenderPlanInfo* info,
                              FileSelectionMode mode,
                              int show_tree,
                              size_t tree_depth,
                              ExportMetrics* metrics) {
     size_t total = 0;
 
-    if (!plan || !metrics) {
+    if (!plan || !info || !metrics || info->count != plan->count) {
         errno = EINVAL;
         return -1;
     }
@@ -493,7 +251,9 @@ int calculate_export_metrics(const ExportPlan* plan,
     }
 
     for (size_t i = 0; i < plan->count; i++) {
-        if (count_entry_bytes(&plan->entries[i], &total) != 0) {
+        size_t fence = 0;
+        if (get_fence_length(info, i, &fence) != 0 ||
+            count_entry_bytes(&plan->entries[i], fence, &total) != 0) {
             return -1;
         }
     }
@@ -504,21 +264,7 @@ int calculate_export_metrics(const ExportPlan* plan,
     return 0;
 }
 
-static int render_entry(FILE* out, const ExportEntry* entry) {
-    size_t max_run = 0;
-    size_t current_run = 0;
-    size_t fence = 3;
-
-    for (size_t i = 0; i < entry->buf_len; i++) {
-        if (entry->buf[i] == '`') {
-            current_run++;
-            if (current_run > max_run) max_run = current_run;
-        } else {
-            current_run = 0;
-        }
-    }
-    fence = (max_run >= 3 ? max_run + 1 : 3);
-
+static int render_entry(FILE* out, const ExportEntry* entry, size_t fence) {
     if (write_text(out, "## ") != 0 ||
         write_markdown_path(out, entry->display_path) != 0 ||
         write_text(out, "\n\n") != 0) {
@@ -540,12 +286,19 @@ static int render_entry(FILE* out, const ExportEntry* entry) {
     return 0;
 }
 
-int render_export_plan(FILE* out, const ExportPlan* plan, int verbose) {
+int render_export_plan(FILE* out, const ExportPlan* plan, const RenderPlanInfo* info, int verbose) {
+    if (!plan || !info || info->count != plan->count) {
+        errno = EINVAL;
+        return -1;
+    }
+
     for (size_t i = 0; i < plan->count; i++) {
+        size_t fence = 0;
         if (verbose) {
             fprintf(stderr, "Processing file: %s\n", plan->entries[i].display_path);
         }
-        if (render_entry(out, &plan->entries[i]) != 0) {
+        if (get_fence_length(info, i, &fence) != 0 ||
+            render_entry(out, &plan->entries[i], fence) != 0) {
             if (ferror(out)) {
                 perror("Error writing export output");
                 return -1;

--- a/render.h
+++ b/render.h
@@ -12,13 +12,20 @@ typedef struct {
     size_t estimated_tokens;
 } ExportMetrics;
 
+typedef struct {
+    size_t* fence_lengths;
+    size_t count;
+} RenderPlanInfo;
+
+int prepare_render_plan(const ExportPlan* plan, RenderPlanInfo* info);
+void free_render_plan_info(RenderPlanInfo* info);
 int calculate_export_metrics(const ExportPlan* plan,
+                             const RenderPlanInfo* info,
                              FileSelectionMode mode,
                              int show_tree,
                              size_t tree_depth,
                              ExportMetrics* metrics);
 int write_export_header(FILE* out, FileSelectionMode mode);
-int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth);
-int render_export_plan(FILE* out, const ExportPlan* plan, int verbose);
+int render_export_plan(FILE* out, const ExportPlan* plan, const RenderPlanInfo* info, int verbose);
 
 #endif

--- a/test_cli.sh
+++ b/test_cli.sh
@@ -27,6 +27,22 @@ assert_not_contains() {
     fi
 }
 
+assert_file_equals() {
+    file=$1
+    expected=$2
+    actual=$(cat "$file")
+    if [ "$actual" != "$expected" ]; then
+        fail "unexpected content in $file"
+    fi
+}
+
+assert_missing() {
+    path=$1
+    if [ -e "$path" ]; then
+        fail "did not expect $path to exist"
+    fi
+}
+
 TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/fuori-cli-test.XXXXXX")
 trap 'rm -rf "$TMPDIR"' EXIT INT TERM
 
@@ -41,6 +57,49 @@ assert_contains "$OUTSIDE/stdout.txt" "This document contains all the source cod
 assert_not_contains "$OUTSIDE/stderr.txt" "Git file-selection modes require"
 assert_not_contains "$OUTSIDE/stderr.txt" "git rev-parse failed"
 
+cat >"$OUTSIDE/notes.md" <<'EOF_NOTES'
+notes
+EOF_NOTES
+(cd "$OUTSIDE" && "$BIN" -o export.md >command_stdout.txt 2>command_stderr.txt)
+assert_contains "$OUTSIDE/export.md" "## main\\.c"
+assert_contains "$OUTSIDE/export.md" "## notes\\.md"
+assert_not_contains "$OUTSIDE/export.md" "export.md"
+assert_not_contains "$OUTSIDE/export.md" ".fuori.tmp."
+
+(cd "$OUTSIDE" && "$BIN" -o - >redirected.md 2>redirect_stderr.txt)
+assert_contains "$OUTSIDE/redirected.md" "## main\\.c"
+assert_contains "$OUTSIDE/redirected.md" "## notes\\.md"
+assert_not_contains "$OUTSIDE/redirected.md" "redirected.md"
+
+cat >"$OUTSIDE/existing.txt" <<'EOF_EXISTING'
+keep me
+EOF_EXISTING
+if (cd "$OUTSIDE" && "$BIN" -o existing.txt --no-clobber >/dev/null 2>no_clobber_stderr.txt); then
+    fail "expected --no-clobber to fail"
+fi
+assert_contains "$OUTSIDE/no_clobber_stderr.txt" "fuori: output file already exists: existing.txt"
+assert_file_equals "$OUTSIDE/existing.txt" "keep me"
+
+TOKEN_DIR="$TMPDIR/tokens"
+mkdir -p "$TOKEN_DIR"
+cat >"$TOKEN_DIR/big.txt" <<'EOF_BIG'
+This file is intentionally long enough to exceed a tiny token budget.
+EOF_BIG
+if (cd "$TOKEN_DIR" && "$BIN" --max-tokens 1 -o blocked.md >/dev/null 2>max_tokens_new_stderr.txt); then
+    fail "expected --max-tokens to fail for missing destination"
+fi
+assert_contains "$TOKEN_DIR/max_tokens_new_stderr.txt" "Error: estimated output is"
+assert_missing "$TOKEN_DIR/blocked.md"
+
+cat >"$TOKEN_DIR/blocked.md" <<'EOF_BLOCKED'
+original content
+EOF_BLOCKED
+if (cd "$TOKEN_DIR" && "$BIN" --max-tokens 1 -o blocked.md >/dev/null 2>max_tokens_existing_stderr.txt); then
+    fail "expected --max-tokens to fail for existing destination"
+fi
+assert_contains "$TOKEN_DIR/max_tokens_existing_stderr.txt" "Error: estimated output is"
+assert_file_equals "$TOKEN_DIR/blocked.md" "original content"
+
 REPO="$TMPDIR/repo"
 mkdir -p "$REPO/sub"
 (cd "$REPO" && git init -q)
@@ -50,7 +109,11 @@ EOF_IGNORE
 cat >"$REPO/sub/tracked.c" <<'EOF_TRACKED'
 int tracked(void) { return 1; }
 EOF_TRACKED
+cat >"$REPO/root_only.c" <<'EOF_ROOT'
+int root_only(void) { return 2; }
+EOF_ROOT
 (cd "$REPO" && git add .gitignore sub/tracked.c && \
+    git add root_only.c && \
     git -c user.name='fuori tests' -c user.email='fuori@example.com' commit -qm init)
 cat >"$REPO/sub/untracked.py" <<'EOF_UNTRACKED'
 print("hello")
@@ -65,6 +128,7 @@ assert_contains "$REPO/sub/stdout.txt" "├── tracked.c"
 assert_contains "$REPO/sub/stdout.txt" "└── untracked.py"
 assert_not_contains "$REPO/sub/stdout.txt" "ignored.log"
 assert_not_contains "$REPO/sub/stdout.txt" ".gitignore"
+assert_not_contains "$REPO/sub/stdout.txt" "root_only.c"
 
 (cd "$REPO" && "$BIN" --no-git -o - >stdout_no_git.txt 2>stderr_no_git.txt)
 assert_contains "$REPO/stdout_no_git.txt" "This document contains all the source code files from the current directory subtree using the local filesystem walker."

--- a/tree.c
+++ b/tree.c
@@ -1,0 +1,318 @@
+#include "tree.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TREE_BRANCH "\xE2\x94\x9C\xE2\x94\x80\xE2\x94\x80 "
+#define TREE_LAST "\xE2\x94\x94\xE2\x94\x80\xE2\x94\x80 "
+#define TREE_PIPE "\xE2\x94\x82   "
+#define TREE_SPACE "    "
+
+typedef struct TreeNode {
+    char* name;
+    int is_dir;
+    struct TreeNode** children;
+    size_t child_count;
+    size_t child_capacity;
+} TreeNode;
+
+static int add_size(size_t* total, size_t amount) {
+    if (*total > SIZE_MAX - amount) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    *total += amount;
+    return 0;
+}
+
+static int write_text(FILE* out, const char* text) {
+    return (fputs(text, out) == EOF) ? -1 : 0;
+}
+
+static int count_text_bytes(size_t* total, const char* text) {
+    return add_size(total, strlen(text));
+}
+
+static int write_visible_text(FILE* out, const char* text) {
+    for (const unsigned char* p = (const unsigned char*)text; *p != '\0'; p++) {
+        unsigned char c = *p;
+        if (c == '\n') {
+            if (write_text(out, "\\n") != 0) return -1;
+            continue;
+        }
+        if (c == '\r') {
+            if (write_text(out, "\\r") != 0) return -1;
+            continue;
+        }
+        if (c == '\t') {
+            if (write_text(out, "\\t") != 0) return -1;
+            continue;
+        }
+        if ((c < 0x20 || c == 0x7f)) {
+            char escaped[5];
+            if (snprintf(escaped, sizeof(escaped), "\\x%02X", c) < 0 ||
+                write_text(out, escaped) != 0) {
+                return -1;
+            }
+            continue;
+        }
+        if (fputc(c, out) == EOF) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int count_visible_text_bytes(size_t* total, const char* text) {
+    for (const unsigned char* p = (const unsigned char*)text; *p != '\0'; p++) {
+        unsigned char c = *p;
+        if (c == '\n' || c == '\r' || c == '\t') {
+            if (add_size(total, 2) != 0) return -1;
+            continue;
+        }
+        if ((c < 0x20 || c == 0x7f)) {
+            if (add_size(total, 4) != 0) return -1;
+            continue;
+        }
+        if (add_size(total, 1) != 0) return -1;
+    }
+    return 0;
+}
+
+static TreeNode* tree_node_create(const char* name, int is_dir) {
+    TreeNode* node = calloc(1, sizeof(*node));
+    if (!node) {
+        return NULL;
+    }
+
+    node->name = strdup(name ? name : "");
+    if (!node->name) {
+        free(node);
+        return NULL;
+    }
+    node->is_dir = is_dir;
+    return node;
+}
+
+static void free_tree(TreeNode* node) {
+    if (!node) return;
+    for (size_t i = 0; i < node->child_count; i++) {
+        free_tree(node->children[i]);
+    }
+    free(node->children);
+    free(node->name);
+    free(node);
+}
+
+static int compare_tree_nodes(const void* lhs, const void* rhs) {
+    const TreeNode* const* left = lhs;
+    const TreeNode* const* right = rhs;
+    if ((*left)->is_dir != (*right)->is_dir) {
+        return (*right)->is_dir - (*left)->is_dir;
+    }
+    return strcmp((*left)->name, (*right)->name);
+}
+
+static int tree_add_path(TreeNode* root, const char* display_path) {
+    char* path_copy = strdup(display_path);
+    if (!path_copy) {
+        return -1;
+    }
+
+    TreeNode* current = root;
+    char* saveptr = NULL;
+    char* token = strtok_r(path_copy, "/", &saveptr);
+    while (token) {
+        char* next = strtok_r(NULL, "/", &saveptr);
+        int is_dir = (next != NULL);
+        TreeNode* child = NULL;
+
+        for (size_t i = 0; i < current->child_count; i++) {
+            if (strcmp(current->children[i]->name, token) == 0) {
+                child = current->children[i];
+                break;
+            }
+        }
+
+        if (!child) {
+            if (current->child_count == current->child_capacity) {
+                size_t new_capacity = (current->child_capacity == 0) ? 8 : current->child_capacity * 2;
+                TreeNode** new_children = realloc(current->children, new_capacity * sizeof(*new_children));
+                if (!new_children) {
+                    free(path_copy);
+                    return -1;
+                }
+                current->children = new_children;
+                current->child_capacity = new_capacity;
+            }
+
+            child = tree_node_create(token, is_dir);
+            if (!child) {
+                free(path_copy);
+                return -1;
+            }
+            current->children[current->child_count++] = child;
+        } else if (is_dir) {
+            child->is_dir = 1;
+        }
+
+        current = child;
+        token = next;
+    }
+
+    free(path_copy);
+    return 0;
+}
+
+static void sort_tree(TreeNode* node) {
+    if (!node) return;
+    if (node->child_count > 1) {
+        qsort(node->children, node->child_count, sizeof(*node->children), compare_tree_nodes);
+    }
+    for (size_t i = 0; i < node->child_count; i++) {
+        sort_tree(node->children[i]);
+    }
+}
+
+static int write_tree_children(FILE* out,
+                               const TreeNode* node,
+                               const char* prefix,
+                               size_t depth,
+                               size_t max_depth) {
+    for (size_t i = 0; i < node->child_count; i++) {
+        const TreeNode* child = node->children[i];
+        int is_last = (i + 1 == node->child_count);
+
+        if (write_text(out, prefix) != 0 ||
+            write_text(out, is_last ? TREE_LAST : TREE_BRANCH) != 0 ||
+            write_visible_text(out, child->name) != 0 ||
+            write_text(out, "\n") != 0) {
+            return -1;
+        }
+
+        if (child->is_dir &&
+            child->child_count > 0 &&
+            (max_depth == SIZE_MAX || depth < max_depth)) {
+            const char* segment = is_last ? TREE_SPACE : TREE_PIPE;
+            size_t prefix_len = strlen(prefix);
+            size_t segment_len = strlen(segment);
+            char* next_prefix = malloc(prefix_len + segment_len + 1);
+            if (!next_prefix) {
+                return -1;
+            }
+            memcpy(next_prefix, prefix, prefix_len);
+            memcpy(next_prefix + prefix_len, segment, segment_len + 1);
+
+            int result = write_tree_children(out, child, next_prefix, depth + 1, max_depth);
+            free(next_prefix);
+            if (result != 0) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int count_tree_children_bytes(const TreeNode* node,
+                                     size_t prefix_len,
+                                     size_t depth,
+                                     size_t max_depth,
+                                     size_t* total) {
+    for (size_t i = 0; i < node->child_count; i++) {
+        const TreeNode* child = node->children[i];
+        int is_last = (i + 1 == node->child_count);
+        const char* branch = is_last ? TREE_LAST : TREE_BRANCH;
+
+        if (add_size(total, prefix_len) != 0 ||
+            add_size(total, strlen(branch)) != 0 ||
+            count_visible_text_bytes(total, child->name) != 0 ||
+            add_size(total, 1) != 0) {
+            return -1;
+        }
+
+        if (child->is_dir &&
+            child->child_count > 0 &&
+            (max_depth == SIZE_MAX || depth < max_depth)) {
+            const char* segment = is_last ? TREE_SPACE : TREE_PIPE;
+            size_t next_prefix_len = prefix_len + strlen(segment);
+            if (next_prefix_len < prefix_len) {
+                errno = EOVERFLOW;
+                return -1;
+            }
+            if (count_tree_children_bytes(child, next_prefix_len, depth + 1, max_depth, total) != 0) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
+    TreeNode* root = tree_node_create("", 1);
+    if (!root) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < plan->count; i++) {
+        if (tree_add_path(root, plan->entries[i].display_path) != 0) {
+            free_tree(root);
+            return -1;
+        }
+    }
+    sort_tree(root);
+
+    if (write_text(out, "## Project Tree\n\n```text\n") != 0) {
+        free_tree(root);
+        return -1;
+    }
+
+    if (root->child_count == 0) {
+        if (write_text(out, "(no exported files)\n") != 0) {
+            free_tree(root);
+            return -1;
+        }
+    } else if (write_tree_children(out, root, "", 1, max_depth) != 0) {
+        free_tree(root);
+        return -1;
+    }
+
+    free_tree(root);
+    return write_text(out, "```\n\n");
+}
+
+int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total) {
+    TreeNode* root = tree_node_create("", 1);
+    if (!root) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < plan->count; i++) {
+        if (tree_add_path(root, plan->entries[i].display_path) != 0) {
+            free_tree(root);
+            return -1;
+        }
+    }
+    sort_tree(root);
+
+    if (count_text_bytes(total, "## Project Tree\n\n```text\n") != 0) {
+        free_tree(root);
+        return -1;
+    }
+
+    if (root->child_count == 0) {
+        if (count_text_bytes(total, "(no exported files)\n") != 0) {
+            free_tree(root);
+            return -1;
+        }
+    } else if (count_tree_children_bytes(root, 0, 1, max_depth, total) != 0) {
+        free_tree(root);
+        return -1;
+    }
+
+    free_tree(root);
+    return count_text_bytes(total, "```\n\n");
+}

--- a/tree.h
+++ b/tree.h
@@ -1,0 +1,12 @@
+#ifndef TREE_H
+#define TREE_H
+
+#include <stddef.h>
+#include <stdio.h>
+
+#include "collect.h"
+
+int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth);
+int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total);
+
+#endif


### PR DESCRIPTION
These changes strengthen `fuori` in two areas: operational safety coverage and internal structure.

It first expands the CLI integration harness to lock down the behaviors that matter most in production. The test suite now covers self-exclusion of final output files, temp-file self-exclusion during export, redirected stdout to a regular file, --no-clobber, Git subdirectory scoping in auto-Git mode, and --max-tokens refusal without mutating the destination, both when the output file does not yet exist and when it already does. The existing ignore matcher tests remain intact.

It then performs a focused refactor without changing user-visible behavior. CLI/config parsing, validation, and requested/resolved mode selection move out of main.c into a dedicated options module, while main.c remains the execution/orchestration layer. Project-tree construction and sizing logic move out of render.c into a tree module. The renderer also stops scanning file buffers twice for Markdown fence lengths: it now prepares renderer-owned per-entry metadata once and reuses it for both byte estimation and final emission. Shared export structures remain format-neutral, and the current in-memory export-plan model is unchanged.


