### PR TITLE
improve CLI output and clarify UTF-8 text export behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,13 @@ Warning: output may exceed 200,000 token context window. Consider using --staged
 
 Use `--warn-tokens <n>` to change the warning threshold, or `--max-tokens <n>` to fail before writing any output when the estimated size would exceed a hard limit.
 
-## Binary File Detection
+## Text File Detection
 
-The application automatically detects binary files by analyzing their content and excludes them from the export.
+`fuori` exports UTF-8 text files and skips inputs that do not pass its text/binary detection path.
+In practice, that means files with NUL bytes, invalid UTF-8, or too many control characters are excluded from the export.
 Empty files are skipped.
 Symbolic links are skipped to avoid recursion cycles.
-UTF-16 encoded files are currently treated as non-exportable and skipped by this detection path.
+UTF-16 and other non-UTF-8 text encodings are currently treated as non-exportable and skipped.
 
 ## Output Format
 

--- a/src/app.h
+++ b/src/app.h
@@ -32,6 +32,10 @@ typedef struct {
     struct stat final_stat;
     int have_temp;
     int have_final;
+    size_t skipped_binary;
+    size_t skipped_too_large;
+    size_t skipped_ignored;
+    size_t skipped_symlink;
 } AppContext;
 
 typedef enum {

--- a/src/collect.c
+++ b/src/collect.c
@@ -292,27 +292,6 @@ static const char* get_language_identifier(const char* filepath,
     return NULL;
 }
 
-static int should_exclude_file(const char* filepath,
-                               const struct stat* st,
-                               size_t max_file_size,
-                               int ancestor_ignored,
-                               const IgnorePattern* patterns,
-                               size_t count) {
-    if (!S_ISREG(st->st_mode)) {
-        return 1;
-    }
-    if (st->st_size < 0) {
-        return 1;
-    }
-    if ((size_t)st->st_size > max_file_size) {
-        return 1;
-    }
-    if (resolve_ignore_state(filepath, patterns, count, 0, ancestor_ignored)) {
-        return 1;
-    }
-    return 0;
-}
-
 static int read_file_buffer(const char* filepath,
                             const struct stat* st,
                             size_t max_file_size,
@@ -520,24 +499,44 @@ static int collect_exportable_file(const char* open_path,
     }
 
     if (respect_ignore) {
-        if (should_exclude_file(open_path,
-                                st,
-                                ctx->max_file_size,
-                                ancestor_ignored,
-                                ctx->ignore_patterns,
-                                ctx->ignore_count)) {
+        if (st->st_size < 0) {
+            return 0;
+        }
+        if ((size_t)st->st_size > ctx->max_file_size) {
+            ctx->skipped_too_large++;
             if (ctx->verbose) {
-                fprintf(stderr, "Skipping file: %s\n", display_path);
+                fprintf(stderr, "Skipping oversized file: %s\n", display_path);
+            }
+            return 0;
+        }
+        if (resolve_ignore_state(open_path,
+                                 ctx->ignore_patterns,
+                                 ctx->ignore_count,
+                                 0,
+                                 ancestor_ignored)) {
+            ctx->skipped_ignored++;
+            if (ctx->verbose) {
+                fprintf(stderr, "Skipping ignored file: %s\n", display_path);
             }
             return 0;
         }
     } else if (st->st_size < 0 || (size_t)st->st_size > ctx->max_file_size) {
+        if (st->st_size >= 0 && (size_t)st->st_size > ctx->max_file_size) {
+            ctx->skipped_too_large++;
+            if (ctx->verbose) {
+                fprintf(stderr, "Skipping oversized file: %s\n", display_path);
+            }
+        }
         return 0;
     }
 
     /* Cache accepted file contents in memory to avoid re-reading at render time. */
     int read_result = read_file_buffer(open_path, st, ctx->max_file_size, &buffer, &bytes_read);
     if (read_result == 1) {
+        ctx->skipped_too_large++;
+        if (ctx->verbose) {
+            fprintf(stderr, "Skipping oversized file: %s\n", display_path);
+        }
         return 0;
     }
     if (read_result != 0) {
@@ -545,6 +544,7 @@ static int collect_exportable_file(const char* open_path,
         return 0;
     }
     if (bytes_read == 0 || is_binary_file(buffer, bytes_read)) {
+        ctx->skipped_binary++;
         if (ctx->verbose) {
             fprintf(stderr, "Skipping binary/empty file: %s\n", display_path);
         }
@@ -645,6 +645,10 @@ static int collect_recursive_paths(const char* base_path,
             continue;
         }
         if (S_ISLNK(st.st_mode)) {
+            ctx->skipped_symlink++;
+            if (ctx->verbose) {
+                fprintf(stderr, "Skipping symlink: %s\n", path);
+            }
             continue;
         }
 
@@ -655,6 +659,7 @@ static int collect_recursive_paths(const char* base_path,
                                                       1,
                                                       ancestor_ignored);
             if (dir_is_ignored) {
+                ctx->skipped_ignored++;
                 if (ctx->verbose) {
                     fprintf(stderr, "Skipping ignored directory: %s\n", path);
                 }
@@ -706,11 +711,17 @@ int collect_selected_export_plan(const SelectedPath* selected_paths,
             perror("Error getting selected file status");
             continue;
         }
+        if (S_ISLNK(st.st_mode)) {
+            ctx->skipped_symlink++;
+            if (ctx->verbose) {
+                fprintf(stderr, "Skipping symlink: %s\n", path->display_path);
+            }
+            continue;
+        }
         if (!S_ISREG(st.st_mode)) {
             continue;
         }
 
-        /* Symlinks are skipped inside collect_exportable_file via the S_ISREG guard above. */
         if (collect_exportable_file(path->open_path, path->display_path, &st, ctx, 0, 0, plan) != 0) {
             return -1;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -76,6 +76,37 @@ static void print_export_summary(const ExportMetrics* metrics) {
     fprintf(stderr, "Est. tokens:    ~%s  (approx, assuming BPE ~3.5 chars/token)\n", tokens_buf);
 }
 
+static void print_verbose_skip_summary(const AppContext* ctx) {
+    char binary_buf[32];
+    char large_buf[32];
+    char ignored_buf[32];
+    char symlink_buf[32];
+
+    if (!ctx || !ctx->verbose) {
+        return;
+    }
+
+    if (format_size_with_commas(ctx->skipped_binary, binary_buf, sizeof(binary_buf)) != 0 ||
+        format_size_with_commas(ctx->skipped_too_large, large_buf, sizeof(large_buf)) != 0 ||
+        format_size_with_commas(ctx->skipped_ignored, ignored_buf, sizeof(ignored_buf)) != 0 ||
+        format_size_with_commas(ctx->skipped_symlink, symlink_buf, sizeof(symlink_buf)) != 0) {
+        fprintf(stderr,
+                "Skipped: binary/empty=%zu, too_large=%zu, ignored=%zu, symlink=%zu\n",
+                ctx->skipped_binary,
+                ctx->skipped_too_large,
+                ctx->skipped_ignored,
+                ctx->skipped_symlink);
+        return;
+    }
+
+    fprintf(stderr,
+            "Skipped: binary/empty=%s, too_large=%s, ignored=%s, symlink=%s\n",
+            binary_buf,
+            large_buf,
+            ignored_buf,
+            symlink_buf);
+}
+
 static int make_temp_output_template(const char* output_path, char* tmpl, size_t tmpl_size) {
     char path_copy[MAX_PATH_LENGTH];
     if (!output_path || !tmpl || tmpl_size == 0) {
@@ -301,12 +332,15 @@ int main(int argc, char* argv[]) {
             goto cleanup;
         }
         temp_created = 0;
-        printf("Codebase exported to %s successfully!\n", ctx.output_path);
-    } else {
+        if (ctx.verbose) {
+            fprintf(stderr, "Codebase exported to %s successfully!\n", ctx.output_path);
+        }
+    } else if (ctx.verbose) {
         fprintf(stderr, "Codebase exported to stdout successfully!\n");
     }
 
     print_export_summary(&metrics);
+    print_verbose_skip_summary(&ctx);
 
     status = 0;
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -65,11 +65,35 @@ assert_contains "$OUTSIDE/export.md" "## main\\.c"
 assert_contains "$OUTSIDE/export.md" "## notes\\.md"
 assert_not_contains "$OUTSIDE/export.md" "export.md"
 assert_not_contains "$OUTSIDE/export.md" ".fuori.tmp."
+assert_file_equals "$OUTSIDE/command_stdout.txt" ""
+assert_not_contains "$OUTSIDE/command_stderr.txt" "Codebase exported to export.md successfully!"
 
 (cd "$OUTSIDE" && "$BIN" -o - >redirected.md 2>redirect_stderr.txt)
 assert_contains "$OUTSIDE/redirected.md" "## main\\.c"
 assert_contains "$OUTSIDE/redirected.md" "## notes\\.md"
 assert_not_contains "$OUTSIDE/redirected.md" "redirected.md"
+
+VERBOSE_DIR="$TMPDIR/verbose"
+mkdir -p "$VERBOSE_DIR"
+cat >"$VERBOSE_DIR/.gitignore" <<'EOF_VERBOSE_IGNORE'
+ignored.txt
+EOF_VERBOSE_IGNORE
+cat >"$VERBOSE_DIR/main.c" <<'EOF_VERBOSE_MAIN'
+int main(void) { return 0; }
+EOF_VERBOSE_MAIN
+cat >"$VERBOSE_DIR/ignored.txt" <<'EOF_VERBOSE_IGNORED'
+ignored
+EOF_VERBOSE_IGNORED
+printf '\000\001\002binary' >"$VERBOSE_DIR/binary.bin"
+awk 'BEGIN { for (i = 0; i < 2048; i++) printf "x"; printf "\n" }' >"$VERBOSE_DIR/large.txt"
+ln -s main.c "$VERBOSE_DIR/link.c"
+
+(cd "$VERBOSE_DIR" && "$BIN" -v -s 1 -o - >verbose_stdout.txt 2>verbose_stderr.txt)
+assert_contains "$VERBOSE_DIR/verbose_stderr.txt" "Skipped: binary/empty=1, too_large=1, ignored=1, symlink=1"
+
+(cd "$OUTSIDE" && "$BIN" -v -o verbose_export.md >verbose_file_stdout.txt 2>verbose_file_stderr.txt)
+assert_file_equals "$OUTSIDE/verbose_file_stdout.txt" ""
+assert_contains "$OUTSIDE/verbose_file_stderr.txt" "Codebase exported to verbose_export.md successfully!"
 
 cat >"$OUTSIDE/existing.txt" <<'EOF_EXISTING'
 keep me


### PR DESCRIPTION
This PR tightens CLI behavior and documentation around output semantics and text detection.

On the CLI side, successful file exports no longer write status messages to stdout by default. This keeps stdout reserved for data and makes the tool more composable in Unix-style workflows. Success messages are now emitted only in verbose mode, and only on stderr. The verbose path also gains aggregate skip counts by reason, reporting how many files were skipped as binary/empty, too large, ignored, or symlinks. CLI coverage was extended to verify both the quiet default behavior and the new verbose-only reporting.

On the documentation side, the README now describes the export policy more precisely. Instead of framing this as generic "binary detection", it now explains that fuori exports UTF-8 text files and skips inputs that fail its text/binary detection path, including files with NUL bytes, invalid UTF-8, too many control characters, empty files, symlinks, and non-UTF-8 encodings such as UTF-16. This better matches the actual behavior of the collector.