### PR TITLE
fix: quiet Git fallback and summary formatting regressions

### DIFF
--- a/src/git_paths.c
+++ b/src/git_paths.c
@@ -34,6 +34,7 @@ void free_selected_paths(SelectedPath* paths, size_t count) {
 }
 
 static int run_command_capture(const char* const argv[],
+                               int suppress_stderr,
                                unsigned char** output,
                                size_t* output_len,
                                int* exit_status,
@@ -78,6 +79,7 @@ static int run_command_capture(const char* const argv[],
 
     if (pid == 0) {
         int child_errno;
+        int null_fd = -1;
         close(stdout_pipe[0]);
         close(error_pipe[0]);
 
@@ -85,6 +87,19 @@ static int run_command_capture(const char* const argv[],
             child_errno = errno;
             write(error_pipe[1], &child_errno, sizeof(child_errno));
             _exit(127);
+        }
+
+        if (suppress_stderr) {
+            null_fd = open("/dev/null", O_WRONLY);
+            if (null_fd == -1 || dup2(null_fd, STDERR_FILENO) == -1) {
+                child_errno = errno;
+                write(error_pipe[1], &child_errno, sizeof(child_errno));
+                if (null_fd != -1) {
+                    close(null_fd);
+                }
+                _exit(127);
+            }
+            close(null_fd);
         }
 
         close(stdout_pipe[1]);
@@ -182,7 +197,7 @@ static int capture_git_line(const char* repo_root,
     if (probe_result) {
         *probe_result = GIT_PROBE_READY;
     }
-    if (run_command_capture(argv, &output, &output_len, &exit_status, &exec_errno) != 0) {
+    if (run_command_capture(argv, quiet_probe, &output, &output_len, &exit_status, &exec_errno) != 0) {
         perror("Error running git");
         return -1;
     }
@@ -411,7 +426,7 @@ int collect_git_paths(FileSelectionMode mode,
     }
     args[argc] = NULL;
 
-    if (run_command_capture(args, &output, &output_len, &exit_status, &exec_errno) != 0) {
+    if (run_command_capture(args, 0, &output, &output_len, &exit_status, &exec_errno) != 0) {
         perror("Error running git");
         goto cleanup;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -19,8 +19,10 @@
 #endif
 
 static int format_size_with_commas(size_t value, char* buffer, size_t buffer_size) {
-    char reversed[64];
-    size_t digits = 0;
+    char digits_buf[64];
+    size_t digit_count = 0;
+    size_t comma_count = 0;
+    size_t total_len = 0;
     size_t used = 0;
 
     if (!buffer || buffer_size == 0) {
@@ -29,24 +31,26 @@ static int format_size_with_commas(size_t value, char* buffer, size_t buffer_siz
     }
 
     do {
-        if (digits >= sizeof(reversed) - 1) {
+        if (digit_count >= sizeof(digits_buf) - 1) {
             errno = EOVERFLOW;
             return -1;
         }
-        if (digits > 0 && digits % 3 == 0) {
-            reversed[digits++] = ',';
-        }
-        reversed[digits++] = (char)('0' + (value % 10));
+        digits_buf[digit_count++] = (char)('0' + (value % 10));
         value /= 10;
     } while (value > 0);
 
-    if (digits + 1 > buffer_size) {
+    comma_count = (digit_count > 0) ? (digit_count - 1) / 3 : 0;
+    total_len = digit_count + comma_count;
+    if (total_len + 1 > buffer_size) {
         errno = ENAMETOOLONG;
         return -1;
     }
 
-    while (digits > 0) {
-        buffer[used++] = reversed[--digits];
+    for (size_t i = digit_count; i > 0; i--) {
+        buffer[used++] = digits_buf[i - 1];
+        if (i > 1 && (i - 1) % 3 == 0) {
+            buffer[used++] = ',';
+        }
     }
     buffer[used] = '\0';
     return 0;

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -64,6 +64,7 @@ EOF_OUTSIDE
 assert_contains "$OUTSIDE/stdout.txt" "This document contains all the source code files from the current directory subtree using the local filesystem walker."
 assert_not_contains "$OUTSIDE/stderr.txt" "Git file-selection modes require"
 assert_not_contains "$OUTSIDE/stderr.txt" "git rev-parse failed"
+assert_not_contains "$OUTSIDE/stderr.txt" "fatal: not a git repository"
 
 cat >"$OUTSIDE/notes.md" <<'EOF_NOTES'
 notes
@@ -131,6 +132,13 @@ if (cd "$TOKEN_DIR" && "$BIN" --max-tokens 1 -o blocked.md >/dev/null 2>max_toke
 fi
 assert_contains "$TOKEN_DIR/max_tokens_existing_stderr.txt" "Error: estimated output is"
 assert_file_equals "$TOKEN_DIR/blocked.md" "original content"
+
+FORMAT_DIR="$TMPDIR/formatting"
+mkdir -p "$FORMAT_DIR"
+awk 'BEGIN { for (i = 0; i < 130000; i++) printf "x"; printf "\n" }' >"$FORMAT_DIR/big.txt"
+(cd "$FORMAT_DIR" && "$BIN" -s 200 -o - >format_stdout.txt 2>format_stderr.txt)
+assert_contains "$FORMAT_DIR/format_stderr.txt" "Bytes written:  130,"
+assert_not_contains "$FORMAT_DIR/format_stderr.txt" "Bytes written:  1,30,"
 
 FAIL_DIR="$TMPDIR/write_failure"
 mkdir -p "$FAIL_DIR/blocked"


### PR DESCRIPTION
Closes #19 

This PR fixes two small but user-visible correctness issues in `fuori`’s CLI behavior.

First, auto Git fallback outside repositories is now truly quiet. The Git probe path previously captured only `stdout`, which meant the child `git rev-parse` process could still leak its own `fatal: not a git repository` message to `stderr` even though `fuori` treated that case as a normal silent fallback to the filesystem walker. Quiet probes now suppress child `stderr`, so running `fuori` in a non-Git directory no longer emits spurious Git noise.

Second, summary number formatting is corrected for large values. The `Bytes written` formatter was inserting commas from the wrong side while constructing the number in reverse, which produced output like `1,30,807` instead of `130,807`. The formatter now groups digits correctly from the final left-to-right representation.

The PR also tightens regression coverage. The CLI harness now asserts that outside-Git fallback does not include leaked `fatal:` output, and it includes a summary-format check to prevent the comma-grouping bug from returning. All tests continue to pass.