### PR TITLE
fix: fail export atomically on render errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 fuori
 test_tree
 test_ignore
+fuori-test
 
 # macOS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CPPFLAGS += -Isrc
 CFLAGS = -Wall -Wextra -Wshadow -Wcast-align -Wwrite-strings -Wredundant-decls \
          -Wstrict-prototypes -Wold-style-definition -std=c99 -O2 -D_POSIX_C_SOURCE=200809L
 TARGET = fuori
+TEST_CLI_TARGET = fuori-test
 SOURCES = src/main.c src/collect.c src/render.c src/git_paths.c src/ignore.c src/options.c src/tree.c
 TEST_TARGET = test_ignore
 TREE_TEST_TARGET = test_tree
@@ -16,19 +17,22 @@ all: $(TARGET)
 $(TARGET): $(SOURCES)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $(TARGET) $(SOURCES)
 
+$(TEST_CLI_TARGET): $(SOURCES)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DFUORI_TESTING -o $(TEST_CLI_TARGET) $(SOURCES)
+
 $(TEST_TARGET): tests/test_ignore.c src/ignore.c src/ignore.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $(TEST_TARGET) tests/test_ignore.c src/ignore.c
 
 $(TREE_TEST_TARGET): tests/test_tree.c src/tree.c src/tree.h src/collect.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $(TREE_TEST_TARGET) tests/test_tree.c src/tree.c
 
-test: $(TARGET) $(TEST_TARGET) $(TREE_TEST_TARGET)
+test: $(TARGET) $(TEST_CLI_TARGET) $(TEST_TARGET) $(TREE_TEST_TARGET)
 	./$(TEST_TARGET)
 	./$(TREE_TEST_TARGET)
-	BIN=./$(TARGET) sh ./tests/test_cli.sh
+	BIN=./$(TEST_CLI_TARGET) sh ./tests/test_cli.sh
 
 clean:
-	rm -f $(TARGET) $(TEST_TARGET) $(TREE_TEST_TARGET)
+	rm -f $(TARGET) $(TEST_CLI_TARGET) $(TEST_TARGET) $(TREE_TEST_TARGET)
 
 install: $(TARGET)
 	install -d $(BINDIR)

--- a/src/main.c
+++ b/src/main.c
@@ -311,8 +311,13 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    errno = 0;
     if (render_export_plan(output_file, &plan, &render_info, ctx.verbose) != 0) {
-        fprintf(stderr, "Error processing export files\n");
+        if (errno != 0) {
+            perror("Error processing export files");
+        } else {
+            fprintf(stderr, "Error processing export files\n");
+        }
         goto cleanup;
     }
 

--- a/src/render.c
+++ b/src/render.c
@@ -7,6 +7,34 @@
 
 #include "tree.h"
 
+#ifdef FUORI_TESTING
+static int maybe_inject_render_failure(size_t index) {
+    static int initialized = 0;
+    static int enabled = 0;
+    static size_t fail_index = 0;
+
+    if (!initialized) {
+        const char* value = getenv("FUORI_TEST_FAIL_RENDER_AT");
+        initialized = 1;
+        if (value && *value != '\0') {
+            char* end = NULL;
+            unsigned long parsed = strtoul(value, &end, 10);
+            if (end != value && *end == '\0') {
+                fail_index = (size_t)parsed;
+                enabled = 1;
+            }
+        }
+    }
+
+    if (enabled && index == fail_index) {
+        errno = EIO;
+        return -1;
+    }
+
+    return 0;
+}
+#endif
+
 static int add_size(size_t* total, size_t amount) {
     if (*total > SIZE_MAX - amount) {
         errno = EOVERFLOW;
@@ -297,13 +325,14 @@ int render_export_plan(FILE* out, const ExportPlan* plan, const RenderPlanInfo* 
         if (verbose) {
             fprintf(stderr, "Processing file: %s\n", plan->entries[i].display_path);
         }
+#ifdef FUORI_TESTING
+        if (maybe_inject_render_failure(i) != 0) {
+            return -1;
+        }
+#endif
         if (get_fence_length(info, i, &fence) != 0 ||
             render_entry(out, &plan->entries[i], fence) != 0) {
-            if (ferror(out)) {
-                perror("Error writing export output");
-                return -1;
-            }
-            fprintf(stderr, "Warning: Failed to render file %s\n", plan->entries[i].display_path);
+            return -1;
         }
     }
     return 0;

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -151,6 +151,24 @@ fi
 assert_contains "$FAIL_DIR/write_failure_stderr.txt" "Error moving temporary file to final destination"
 assert_no_temp_outputs "$FAIL_DIR"
 
+RENDER_FAIL_DIR="$TMPDIR/render_failure"
+mkdir -p "$RENDER_FAIL_DIR"
+cat >"$RENDER_FAIL_DIR/a.c" <<'EOF_RENDER_A'
+int a(void) { return 1; }
+EOF_RENDER_A
+cat >"$RENDER_FAIL_DIR/b.c" <<'EOF_RENDER_B'
+int b(void) { return 2; }
+EOF_RENDER_B
+cat >"$RENDER_FAIL_DIR/export.md" <<'EOF_RENDER_EXISTING'
+original artifact
+EOF_RENDER_EXISTING
+if (cd "$RENDER_FAIL_DIR" && FUORI_TEST_FAIL_RENDER_AT=1 "$BIN" -o export.md >/dev/null 2>render_failure_stderr.txt); then
+    fail "expected render failure to abort export"
+fi
+assert_contains "$RENDER_FAIL_DIR/render_failure_stderr.txt" "Error processing export files"
+assert_file_equals "$RENDER_FAIL_DIR/export.md" "original artifact"
+assert_no_temp_outputs "$RENDER_FAIL_DIR"
+
 PERM_DIR="$TMPDIR/permissions"
 mkdir -p "$PERM_DIR"
 cat >"$PERM_DIR/main.c" <<'EOF_PERM_MAIN'


### PR DESCRIPTION
Make rendering all-or-nothing by aborting the export on any get_fence_length() or render_entry() failure, preserving error context in main(), and preventing partial temp output from being renamed into place. Add deterministic CLI regression coverage for mid-render failure to verify nonzero exit, preserved destination content, and temp-file cleanup.