### PR TITLE
document defaults and internal cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ You can create a `.gitignore` file in the directory to specify files and pattern
 These rules apply to the recursive filesystem walker, including `--no-git` mode and automatic fallback outside Git repositories.
 This tool supports common gitignore-style rules, including comments, `!` negation, trailing `/` for directories,
 root-anchored `/` patterns, and recursive `**` path globs such as `**/node_modules/` and `**/*.pyc`.
+In filesystem mode, `fuori` also seeds a small built-in default ignore list even when no `.gitignore` is present:
+`.git/`, `node_modules/`, `build/`, `dist/`, `bin/`, `.venv/`, `__pycache__/`, `.env`, `.DS_Store`,
+and common compiled/log artifacts such as `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, and `*.log`.
+If you need those paths exported, use stdin selection or move the files outside those default patterns.
 
 ```
 # Ignore build directories

--- a/src/app.h
+++ b/src/app.h
@@ -2,7 +2,6 @@
 #define APP_H
 
 #include <stddef.h>
-#include <stdint.h>
 #include <sys/stat.h>
 
 #define MAX_FILE_SIZE (100 * 1024)

--- a/src/collect.c
+++ b/src/collect.c
@@ -144,6 +144,7 @@ static int is_likely_utf8(const unsigned char* s, size_t n) {
 }
 
 static int is_binary_file(const unsigned char* buffer, size_t bytes_read) {
+    /* Empty files are filtered by the caller; this helper only classifies non-empty content. */
     if (bytes_read == 0) return 0;
 
     for (size_t i = 0; i < bytes_read; i++) {
@@ -521,7 +522,15 @@ static int collect_exportable_file(const char* open_path,
         fprintf(stderr, "Warning: Failed to process file %s\n", display_path);
         return 0;
     }
-    if (bytes_read == 0 || is_binary_file(buffer, bytes_read)) {
+    if (bytes_read == 0) {
+        ctx->skipped_binary++;
+        if (ctx->verbose) {
+            fprintf(stderr, "Skipping binary/empty file: %s\n", display_path);
+        }
+        free(buffer);
+        return 0;
+    }
+    if (is_binary_file(buffer, bytes_read)) {
         ctx->skipped_binary++;
         if (ctx->verbose) {
             fprintf(stderr, "Skipping binary/empty file: %s\n", display_path);

--- a/src/options.c
+++ b/src/options.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/render.c
+++ b/src/render.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "text_io.h"
 #include "tree.h"
 
 #ifdef FUORI_TESTING
@@ -68,10 +69,6 @@ static size_t estimate_tokens(size_t byte_count) {
     return (byte_count / 7) * 2 + ((byte_count % 7) * 2) / 7;
 }
 
-static int write_text(FILE* out, const char* text) {
-    return (fputs(text, out) == EOF) ? -1 : 0;
-}
-
 static int write_bytes(FILE* out, const void* data, size_t len) {
     return (fwrite(data, 1, len, out) == len) ? 0 : -1;
 }
@@ -82,29 +79,29 @@ static int write_markdown_path(FILE* out, const char* path) {
     for (const unsigned char* p = (const unsigned char*)path; *p != '\0'; p++) {
         unsigned char c = *p;
         if (c == '&') {
-            if (write_text(out, "&amp;") != 0) return -1;
+            if (fuori_write_text(out, "&amp;") != 0) return -1;
             continue;
         }
         if (c == '<') {
-            if (write_text(out, "&lt;") != 0) return -1;
+            if (fuori_write_text(out, "&lt;") != 0) return -1;
             continue;
         }
         if (c == '\n') {
-            if (write_text(out, "\\n") != 0) return -1;
+            if (fuori_write_text(out, "\\n") != 0) return -1;
             continue;
         }
         if (c == '\r') {
-            if (write_text(out, "\\r") != 0) return -1;
+            if (fuori_write_text(out, "\\r") != 0) return -1;
             continue;
         }
         if (c == '\t') {
-            if (write_text(out, "\\t") != 0) return -1;
+            if (fuori_write_text(out, "\\t") != 0) return -1;
             continue;
         }
         if ((c < 0x20 || c == 0x7f)) {
             char escaped[5];
             if (snprintf(escaped, sizeof(escaped), "\\x%02X", c) < 0 ||
-                write_text(out, escaped) != 0) {
+                fuori_write_text(out, escaped) != 0) {
                 return -1;
             }
             continue;
@@ -117,10 +114,6 @@ static int write_markdown_path(FILE* out, const char* path) {
         }
     }
     return 0;
-}
-
-static int count_text_bytes(size_t* total, const char* text) {
-    return add_size(total, strlen(text));
 }
 
 static int count_markdown_path_bytes(size_t* total, const char* path) {
@@ -163,16 +156,16 @@ static int write_fence(FILE* out, size_t count, const char* lang) {
     for (size_t i = 0; i < count; i++) {
         if (fputc('`', out) == EOF) return -1;
     }
-    if (lang && *lang && write_text(out, lang) != 0) return -1;
+    if (lang && *lang && fuori_write_text(out, lang) != 0) return -1;
     return (fputc('\n', out) == EOF) ? -1 : 0;
 }
 
 int write_export_header(FILE* out, FileSelectionMode mode) {
-    if (write_text(out, "# Codebase Export\n\n") != 0) {
+    if (fuori_write_text(out, "# Codebase Export\n\n") != 0) {
         return -1;
     }
 
-    return write_text(out, export_description(mode));
+    return fuori_write_text(out, export_description(mode));
 }
 
 static size_t compute_fence_length(const ExportEntry* entry) {
@@ -240,9 +233,9 @@ static int get_fence_length(const RenderPlanInfo* info, size_t index, size_t* fe
 }
 
 static int count_entry_bytes(const ExportEntry* entry, size_t fence, size_t* total) {
-    if (count_text_bytes(total, "## ") != 0 ||
+    if (fuori_count_text_bytes(total, "## ") != 0 ||
         count_markdown_path_bytes(total, entry->display_path) != 0 ||
-        count_text_bytes(total, "\n\n") != 0 ||
+        fuori_count_text_bytes(total, "\n\n") != 0 ||
         count_fence_bytes(total, fence, entry->lang) != 0 ||
         add_size(total, entry->buf_len) != 0) {
         return -1;
@@ -252,7 +245,7 @@ static int count_entry_bytes(const ExportEntry* entry, size_t fence, size_t* tot
         return -1;
     }
     if (count_fence_bytes(total, fence, NULL) != 0 ||
-        count_text_bytes(total, "\n\n") != 0) {
+        fuori_count_text_bytes(total, "\n\n") != 0) {
         return -1;
     }
     return 0;
@@ -271,8 +264,8 @@ int calculate_export_metrics(const ExportPlan* plan,
         return -1;
     }
 
-    if (count_text_bytes(&total, "# Codebase Export\n\n") != 0 ||
-        count_text_bytes(&total, export_description(mode)) != 0) {
+    if (fuori_count_text_bytes(&total, "# Codebase Export\n\n") != 0 ||
+        fuori_count_text_bytes(&total, export_description(mode)) != 0) {
         return -1;
     }
 
@@ -295,9 +288,9 @@ int calculate_export_metrics(const ExportPlan* plan,
 }
 
 static int render_entry(FILE* out, const ExportEntry* entry, size_t fence) {
-    if (write_text(out, "## ") != 0 ||
+    if (fuori_write_text(out, "## ") != 0 ||
         write_markdown_path(out, entry->display_path) != 0 ||
-        write_text(out, "\n\n") != 0) {
+        fuori_write_text(out, "\n\n") != 0) {
         return -1;
     }
     if (write_fence(out, fence, entry->lang) != 0) {
@@ -306,11 +299,11 @@ static int render_entry(FILE* out, const ExportEntry* entry, size_t fence) {
     if (entry->buf_len > 0 && write_bytes(out, entry->buf, entry->buf_len) != 0) {
         return -1;
     }
-    if (entry->buf_len > 0 && entry->buf[entry->buf_len - 1] != '\n' && write_text(out, "\n") != 0) {
+    if (entry->buf_len > 0 && entry->buf[entry->buf_len - 1] != '\n' && fuori_write_text(out, "\n") != 0) {
         return -1;
     }
     if (write_fence(out, fence, NULL) != 0 ||
-        write_text(out, "\n\n") != 0) {
+        fuori_write_text(out, "\n\n") != 0) {
         return -1;
     }
     return 0;

--- a/src/text_io.h
+++ b/src/text_io.h
@@ -1,0 +1,24 @@
+#ifndef TEXT_IO_H
+#define TEXT_IO_H
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+static inline int fuori_write_text(FILE* out, const char* text) {
+    return (fputs(text, out) == EOF) ? -1 : 0;
+}
+
+static inline int fuori_count_text_bytes(size_t* total, const char* text) {
+    size_t text_len = strlen(text);
+    if (*total > SIZE_MAX - text_len) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    *total += text_len;
+    return 0;
+}
+
+#endif

--- a/src/tree.c
+++ b/src/tree.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "text_io.h"
+
 #define TREE_BRANCH "\xE2\x94\x9C\xE2\x94\x80\xE2\x94\x80 "
 #define TREE_LAST "\xE2\x94\x94\xE2\x94\x80\xE2\x94\x80 "
 #define TREE_PIPE "\xE2\x94\x82   "
@@ -31,10 +33,6 @@ static int add_size(size_t* total, size_t amount) {
     }
     *total += amount;
     return 0;
-}
-
-static int write_text(FILE* out, const char* text) {
-    return (fputs(text, out) == EOF) ? -1 : 0;
 }
 
 static int ensure_prefix_capacity(TreePrefixBuffer* prefix, size_t needed_len) {
@@ -81,29 +79,25 @@ static int append_prefix_segment(TreePrefixBuffer* prefix, const char* segment) 
     return 0;
 }
 
-static int count_text_bytes(size_t* total, const char* text) {
-    return add_size(total, strlen(text));
-}
-
 static int write_visible_text(FILE* out, const char* text) {
     for (const unsigned char* p = (const unsigned char*)text; *p != '\0'; p++) {
         unsigned char c = *p;
         if (c == '\n') {
-            if (write_text(out, "\\n") != 0) return -1;
+            if (fuori_write_text(out, "\\n") != 0) return -1;
             continue;
         }
         if (c == '\r') {
-            if (write_text(out, "\\r") != 0) return -1;
+            if (fuori_write_text(out, "\\r") != 0) return -1;
             continue;
         }
         if (c == '\t') {
-            if (write_text(out, "\\t") != 0) return -1;
+            if (fuori_write_text(out, "\\t") != 0) return -1;
             continue;
         }
         if ((c < 0x20 || c == 0x7f)) {
             char escaped[5];
             if (snprintf(escaped, sizeof(escaped), "\\x%02X", c) < 0 ||
-                write_text(out, escaped) != 0) {
+                fuori_write_text(out, escaped) != 0) {
                 return -1;
             }
             continue;
@@ -235,10 +229,10 @@ static int write_tree_children(FILE* out,
         const TreeNode* child = node->children[i];
         int is_last = (i + 1 == node->child_count);
 
-        if (write_text(out, prefix->data ? prefix->data : "") != 0 ||
-            write_text(out, is_last ? TREE_LAST : TREE_BRANCH) != 0 ||
+        if (fuori_write_text(out, prefix->data ? prefix->data : "") != 0 ||
+            fuori_write_text(out, is_last ? TREE_LAST : TREE_BRANCH) != 0 ||
             write_visible_text(out, child->name) != 0 ||
-            write_text(out, "\n") != 0) {
+            fuori_write_text(out, "\n") != 0) {
             return -1;
         }
 
@@ -315,13 +309,13 @@ int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
     }
     sort_tree(root);
 
-    if (write_text(out, "## Project Tree\n\n```text\n") != 0) {
+    if (fuori_write_text(out, "## Project Tree\n\n```text\n") != 0) {
         free_tree(root);
         return -1;
     }
 
     if (root->child_count == 0) {
-        if (write_text(out, "(no exported files)\n") != 0) {
+        if (fuori_write_text(out, "(no exported files)\n") != 0) {
             goto cleanup;
         }
     } else {
@@ -334,7 +328,7 @@ int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
         }
     }
 
-    result = write_text(out, "```\n\n");
+    result = fuori_write_text(out, "```\n\n");
 
 cleanup:
     free(prefix.data);
@@ -356,13 +350,13 @@ int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* t
     }
     sort_tree(root);
 
-    if (count_text_bytes(total, "## Project Tree\n\n```text\n") != 0) {
+    if (fuori_count_text_bytes(total, "## Project Tree\n\n```text\n") != 0) {
         free_tree(root);
         return -1;
     }
 
     if (root->child_count == 0) {
-        if (count_text_bytes(total, "(no exported files)\n") != 0) {
+        if (fuori_count_text_bytes(total, "(no exported files)\n") != 0) {
             free_tree(root);
             return -1;
         }
@@ -372,5 +366,5 @@ int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* t
     }
 
     free_tree(root);
-    return count_text_bytes(total, "```\n\n");
+    return fuori_count_text_bytes(total, "```\n\n");
 }


### PR DESCRIPTION
Document the built-in filesystem ignore defaults in the README, remove the unused stdint.h include from app.h, clarify empty-file handling so the collector distinguishes caller-managed empty inputs from binary detection, and deduplicate the shared text write/byte-count helpers used by the tree and render paths into a small internal header.