### PR TITLE
fix: tree fence escaping and ignored-dir negation handling

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -292,6 +292,10 @@ int resolve_ignore_state(const char* filepath,
         }
 
         if (!pattern->use_path_match) {
+            /* Basename negations should not resurrect descendants of an ignored directory. */
+            if (initial_ignored && pattern->negated) {
+                continue;
+            }
             if (fnmatch(pattern->match_pattern, base, 0) == 0) {
                 ignored = !pattern->negated;
             }

--- a/src/tree.c
+++ b/src/tree.c
@@ -125,6 +125,28 @@ static int count_visible_text_bytes(size_t* total, const char* text) {
     return 0;
 }
 
+static size_t max_backtick_run_in_text(const char* text) {
+    size_t max_run = 0;
+    size_t current_run = 0;
+
+    if (!text) {
+        return 0;
+    }
+
+    for (const unsigned char* p = (const unsigned char*)text; *p != '\0'; p++) {
+        if (*p == '`') {
+            current_run++;
+            if (current_run > max_run) {
+                max_run = current_run;
+            }
+        } else {
+            current_run = 0;
+        }
+    }
+
+    return max_run;
+}
+
 static TreeNode* tree_node_create(const char* name, int is_dir) {
     TreeNode* node = calloc(1, sizeof(*node));
     if (!node) {
@@ -220,6 +242,60 @@ static void sort_tree(TreeNode* node) {
     }
 }
 
+static size_t max_backtick_run_in_tree(const TreeNode* node) {
+    size_t max_run = max_backtick_run_in_text(node ? node->name : NULL);
+
+    if (!node) {
+        return 0;
+    }
+
+    for (size_t i = 0; i < node->child_count; i++) {
+        size_t child_run = max_backtick_run_in_tree(node->children[i]);
+        if (child_run > max_run) {
+            max_run = child_run;
+        }
+    }
+
+    return max_run;
+}
+
+static size_t compute_tree_fence_length(const TreeNode* node) {
+    size_t max_run = max_backtick_run_in_tree(node);
+    return (max_run >= 3) ? max_run + 1 : 3;
+}
+
+static int write_tree_open_fence(FILE* out, size_t fence_len) {
+    for (size_t i = 0; i < fence_len; i++) {
+        if (fputc('`', out) == EOF) {
+            return -1;
+        }
+    }
+    return fuori_write_text(out, "text\n");
+}
+
+static int write_tree_close_fence(FILE* out, size_t fence_len) {
+    for (size_t i = 0; i < fence_len; i++) {
+        if (fputc('`', out) == EOF) {
+            return -1;
+        }
+    }
+    return fuori_write_text(out, "\n\n");
+}
+
+static int count_tree_open_fence_bytes(size_t* total, size_t fence_len) {
+    if (add_size(total, fence_len) != 0) {
+        return -1;
+    }
+    return add_size(total, strlen("text\n"));
+}
+
+static int count_tree_close_fence_bytes(size_t* total, size_t fence_len) {
+    if (add_size(total, fence_len) != 0) {
+        return -1;
+    }
+    return add_size(total, 2);
+}
+
 static int write_tree_children(FILE* out,
                                const TreeNode* node,
                                TreePrefixBuffer* prefix,
@@ -296,6 +372,7 @@ static int count_tree_children_bytes(const TreeNode* node,
 int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
     TreeNode* root = tree_node_create("", 1);
     TreePrefixBuffer prefix = {0};
+    size_t fence_len = 3;
     int result = -1;
     if (!root) {
         return -1;
@@ -308,8 +385,10 @@ int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
         }
     }
     sort_tree(root);
+    fence_len = compute_tree_fence_length(root);
 
-    if (fuori_write_text(out, "## Project Tree\n\n```text\n") != 0) {
+    if (fuori_write_text(out, "## Project Tree\n\n") != 0 ||
+        write_tree_open_fence(out, fence_len) != 0) {
         free_tree(root);
         return -1;
     }
@@ -328,7 +407,7 @@ int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
         }
     }
 
-    result = fuori_write_text(out, "```\n\n");
+    result = write_tree_close_fence(out, fence_len);
 
 cleanup:
     free(prefix.data);
@@ -338,6 +417,7 @@ cleanup:
 
 int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total) {
     TreeNode* root = tree_node_create("", 1);
+    size_t fence_len = 3;
     if (!root) {
         return -1;
     }
@@ -349,8 +429,10 @@ int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* t
         }
     }
     sort_tree(root);
+    fence_len = compute_tree_fence_length(root);
 
-    if (fuori_count_text_bytes(total, "## Project Tree\n\n```text\n") != 0) {
+    if (fuori_count_text_bytes(total, "## Project Tree\n\n") != 0 ||
+        count_tree_open_fence_bytes(total, fence_len) != 0) {
         free_tree(root);
         return -1;
     }
@@ -366,5 +448,5 @@ int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* t
     }
 
     free_tree(root);
-    return fuori_count_text_bytes(total, "```\n\n");
+    return count_tree_close_fence_bytes(total, fence_len);
 }

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -212,6 +212,28 @@ assert_contains "$ODD_DIR/odd_stdout.txt" "## file with spaces\\.txt"
 assert_contains "$ODD_DIR/odd_stdout.txt" "## café\\.py"
 assert_contains "$ODD_DIR/odd_stdout.txt" "## weird &amp; &lt;name\\>\\.txt"
 
+TREE_FENCE_DIR="$TMPDIR/tree_fence"
+mkdir -p "$TREE_FENCE_DIR/src"
+TREE_FENCE_FILE="$TREE_FENCE_DIR/src/"'```name.c'
+cat >"$TREE_FENCE_FILE" <<'EOF_TREE_FENCE'
+int tree_fence(void) { return 0; }
+EOF_TREE_FENCE
+(cd "$TREE_FENCE_DIR" && "$BIN" -o - >tree_fence_stdout.txt 2>tree_fence_stderr.txt)
+assert_contains "$TREE_FENCE_DIR/tree_fence_stdout.txt" '````text'
+assert_contains "$TREE_FENCE_DIR/tree_fence_stdout.txt" '└── ```name.c'
+
+IGNORE_NEGATION_DIR="$TMPDIR/ignore_negation"
+mkdir -p "$IGNORE_NEGATION_DIR/build"
+cat >"$IGNORE_NEGATION_DIR/.gitignore" <<'EOF_IGNORE_NEGATION'
+build/
+!keep.txt
+EOF_IGNORE_NEGATION
+cat >"$IGNORE_NEGATION_DIR/build/keep.txt" <<'EOF_IGNORE_KEEP'
+keep
+EOF_IGNORE_KEEP
+(cd "$IGNORE_NEGATION_DIR" && "$BIN" --no-git -o - >ignore_negation_stdout.txt 2>ignore_negation_stderr.txt)
+assert_not_contains "$IGNORE_NEGATION_DIR/ignore_negation_stdout.txt" "build/keep\\.txt"
+
 STDIN_DIR="$TMPDIR/stdin_selection"
 mkdir -p "$STDIN_DIR/ignored"
 cat >"$STDIN_DIR/.gitignore" <<'EOF_STDIN_IGNORE'

--- a/tests/test_ignore.c
+++ b/tests/test_ignore.c
@@ -146,6 +146,14 @@ int main(void) {
             .is_dir = 0,
             .expected = 0,
             .patterns = {"**/*.pyc", "!src/keep.pyc", NULL}
+        },
+        {
+            .name = "ignored parent blocks basename negation",
+            .path = "build/keep.txt",
+            .is_dir = 0,
+            .initial_ignored = 1,
+            .expected = 1,
+            .patterns = {"build/", "!keep.txt", NULL}
         }
     };
 

--- a/tests/test_tree.c
+++ b/tests/test_tree.c
@@ -33,7 +33,8 @@ static int build_plan(ExportPlan* plan) {
     static const char* const paths[] = {
         "alpha/deep/leaf.txt",
         "alpha/shallow.txt",
-        "beta.txt"
+        "beta.txt",
+        "tick/```name.txt"
     };
 
     memset(plan, 0, sizeof(*plan));
@@ -139,13 +140,18 @@ int main(void) {
     failures += assert_contains(full_output, "├── alpha\n", "root alpha branch");
     failures += assert_contains(full_output, "│   ├── deep\n", "nested deep branch");
     failures += assert_contains(full_output, "│   └── shallow.txt\n", "sibling shallow branch");
+    failures += assert_contains(full_output, "├── tick\n", "backtick directory branch");
+    failures += assert_contains(full_output, "│   └── ```name.txt\n", "backtick filename branch");
     failures += assert_contains(full_output, "└── beta.txt\n", "root beta sibling");
     failures += assert_not_contains(full_output, "│       └── shallow.txt\n", "leaked deep prefix");
+    failures += assert_contains(full_output, "````text\n", "expanded tree fence");
 
     failures += assert_contains(shallow_output, "├── alpha\n", "depth-limited alpha");
+    failures += assert_contains(shallow_output, "├── tick\n", "depth-limited tick");
     failures += assert_contains(shallow_output, "└── beta.txt\n", "depth-limited beta");
     failures += assert_not_contains(shallow_output, "deep\n", "depth-limited deep omission");
     failures += assert_not_contains(shallow_output, "shallow.txt\n", "depth-limited shallow omission");
+    failures += assert_contains(shallow_output, "````text\n", "depth-limited expanded tree fence");
 
     free(full_output);
     free(shallow_output);


### PR DESCRIPTION
Prevent malformed Markdown when project tree filenames contain backticks by sizing the tree fence dynamically, and tighten filesystem ignore matching so basename-only negations do not re-include files inside already ignored directories. Add unit and CLI regressions covering both cases while preserving explicit path negations like `!build/keep.txt`.