### PR TITLE
add change context to staged, unstaged, and diff exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Git selection flags (`--staged`, `--unstaged`, `--diff`) and `--from-stdin` are 
 
 ```bash
 fuori                              # Export current working tree
+fuori --unstaged                   # Export unstaged changes
 fuori --staged -o review.md        # Staged changes to a named file
 fuori --diff HEAD~3..HEAD          # Files changed in the last 3 commits
 fuori --diff main...HEAD           # Changes since branching from main
@@ -117,7 +118,7 @@ fuori --no-tree                    # Skip the project tree section
 fuori --tree-depth 2               # Shallow tree
 fuori -s 50                        # 50 KB file size cap
 fuori --warn-tokens 100000         # Earlier token warning
-fuori --max-tokens 180000          # Hard token budget
+fuori --max-tokens 270000          # Hard token budget
 fuori -o out.md --no-clobber       # Refuse to overwrite
 ```
 
@@ -159,9 +160,9 @@ Use `--no-git` to force the filesystem walker explicitly.
 | Mode | Git command |
 |---|---|
 | Default | `git ls-files -z --cached --others --exclude-standard` |
-| `--staged` | `git diff --cached --name-only --diff-filter=AMR` |
-| `--unstaged` | `git diff --name-only --diff-filter=AMR` |
-| `--diff <range>` | `git diff --name-only <range>` (two-dot and three-dot ranges both work) |
+| `--staged` | `git diff --cached --name-status --diff-filter=AMR` |
+| `--unstaged` | `git diff --name-status --diff-filter=AMR` |
+| `--diff <range>` | `git diff --name-status --diff-filter=AMR <range>` (two-dot and three-dot ranges both work) |
 
 Additional semantics:
 
@@ -170,6 +171,7 @@ Additional semantics:
 - Git-selected files still go through normal export-time checks such as regular-file validation, symlink skipping, binary detection, size limits, and output-file self-exclusion
 - `--unstaged` does not include untracked files
 - Renamed files are exported under the current path reported by Git
+- `--staged`, `--unstaged`, and `--diff` include a `Change Context` section with change status summaries
 - If Git selects no files, `fuori` still succeeds and writes an empty export
 
 ## Stdin File Selection
@@ -228,11 +230,12 @@ UTF-16 and other non-UTF-8 text encodings are currently treated as non-exportabl
 The output markdown file will contain:
 
 1. A preamble with repository, mode, and generation timestamp metadata plus a short mode description
-2. A project tree section that reflects the exported artifact (enabled by default)
-3. A header with the file path
-4. A code block with the file content
-5. Appropriate language identifiers for syntax highlighting
-6. A `stderr` summary of files, bytes, and estimated tokens after successful completion
+2. A `Change Context` section for `--staged`, `--unstaged`, and `--diff` exports
+3. A project tree section that reflects the exported artifact (enabled by default)
+4. A header with the file path
+5. A code block with the file content
+6. Appropriate language identifiers for syntax highlighting
+7. A `stderr` summary of files, bytes, and estimated tokens after successful completion
 
 Example file contents excerpt (the `Makefile` section is omitted for brevity):
 ````markdown

--- a/src/git_paths.c
+++ b/src/git_paths.c
@@ -22,7 +22,16 @@ static int compare_selected_paths(const void* lhs, const void* rhs) {
     if (display_cmp != 0) {
         return display_cmp;
     }
-    return strcmp(left->open_path, right->open_path);
+    int open_cmp = strcmp(left->open_path, right->open_path);
+    if (open_cmp != 0) {
+        return open_cmp;
+    }
+    if (left->change_type != right->change_type) {
+        return (left->change_type < right->change_type) ? -1 : 1;
+    }
+    const char* left_previous = left->previous_display_path ? left->previous_display_path : "";
+    const char* right_previous = right->previous_display_path ? right->previous_display_path : "";
+    return strcmp(left_previous, right_previous);
 }
 
 void free_selected_paths(SelectedPath* paths, size_t count) {
@@ -30,6 +39,7 @@ void free_selected_paths(SelectedPath* paths, size_t count) {
     for (size_t i = 0; i < count; i++) {
         free(paths[i].open_path);
         free(paths[i].display_path);
+        free(paths[i].previous_display_path);
     }
     free(paths);
 }
@@ -49,17 +59,23 @@ static int normalize_selected_paths(SelectedPath* paths, size_t* count) {
         size_t unique_count = 1;
         for (size_t i = 1; i < *count; i++) {
             if (strcmp(paths[i - 1].open_path, paths[i].open_path) == 0 &&
-                strcmp(paths[i - 1].display_path, paths[i].display_path) == 0) {
+                strcmp(paths[i - 1].display_path, paths[i].display_path) == 0 &&
+                paths[i - 1].change_type == paths[i].change_type &&
+                strcmp(paths[i - 1].previous_display_path ? paths[i - 1].previous_display_path : "",
+                       paths[i].previous_display_path ? paths[i].previous_display_path : "") == 0) {
                 free(paths[i].open_path);
                 free(paths[i].display_path);
+                free(paths[i].previous_display_path);
                 paths[i].open_path = NULL;
                 paths[i].display_path = NULL;
+                paths[i].previous_display_path = NULL;
                 continue;
             }
             if (unique_count != i) {
                 paths[unique_count] = paths[i];
                 paths[i].open_path = NULL;
                 paths[i].display_path = NULL;
+                paths[i].previous_display_path = NULL;
             }
             unique_count++;
         }
@@ -288,11 +304,19 @@ static int append_selected_path(SelectedPath** paths,
                                 const char* prefix,
                                 size_t prefix_len,
                                 const char* repo_rel,
-                                size_t repo_rel_len) {
+                                size_t repo_rel_len,
+                                SelectedPathChangeType change_type,
+                                const char* previous_repo_rel) {
     const char* display_rel = repo_rel;
+    const char* previous_display_rel = previous_repo_rel;
     if (prefix_len > 0 &&
         strncmp(repo_rel, prefix, prefix_len) == 0) {
         display_rel = repo_rel + prefix_len;
+    }
+    if (previous_repo_rel &&
+        prefix_len > 0 &&
+        strncmp(previous_repo_rel, prefix, prefix_len) == 0) {
+        previous_display_rel = previous_repo_rel + prefix_len;
     }
 
     if (*count == *capacity) {
@@ -320,6 +344,19 @@ static int append_selected_path(SelectedPath** paths,
         free((*paths)[*count].open_path);
         (*paths)[*count].open_path = NULL;
         return -1;
+    }
+
+    (*paths)[*count].change_type = change_type;
+    (*paths)[*count].previous_display_path = NULL;
+    if (previous_display_rel) {
+        (*paths)[*count].previous_display_path = strdup(previous_display_rel);
+        if (!(*paths)[*count].previous_display_path) {
+            free((*paths)[*count].open_path);
+            free((*paths)[*count].display_path);
+            (*paths)[*count].open_path = NULL;
+            (*paths)[*count].display_path = NULL;
+            return -1;
+        }
     }
 
     (*count)++;
@@ -356,17 +393,19 @@ static int append_literal_selected_path(SelectedPath** paths,
     }
     memcpy((*paths)[*count].display_path, path, path_len);
     (*paths)[*count].display_path[path_len] = '\0';
+    (*paths)[*count].change_type = SELECTED_PATH_CHANGE_NONE;
+    (*paths)[*count].previous_display_path = NULL;
 
     (*count)++;
     return 0;
 }
 
-static int parse_selected_paths_output(const unsigned char* output,
-                                       size_t output_len,
-                                       const char* repo_root,
-                                       const char* prefix,
-                                       SelectedPath** paths_out,
-                                       size_t* count_out) {
+static int parse_name_only_output(const unsigned char* output,
+                                  size_t output_len,
+                                  const char* repo_root,
+                                  const char* prefix,
+                                  SelectedPath** paths_out,
+                                  size_t* count_out) {
     SelectedPath* paths = NULL;
     size_t count = 0;
     size_t capacity = 0;
@@ -390,12 +429,147 @@ static int parse_selected_paths_output(const unsigned char* output,
                                      prefix,
                                      prefix_len,
                                      repo_rel,
-                                     repo_rel_len) != 0) {
+                                     repo_rel_len,
+                                     SELECTED_PATH_CHANGE_NONE,
+                                     NULL) != 0) {
                 free_selected_paths(paths, count);
                 return -1;
             }
         }
         start = end + 1;
+    }
+
+    if (normalize_selected_paths(paths, &count) != 0) {
+        free_selected_paths(paths, count);
+        return -1;
+    }
+
+    *paths_out = paths;
+    *count_out = count;
+    return 0;
+}
+
+static SelectedPathChangeType parse_change_type(const char* status) {
+    if (!status || status[0] == '\0') {
+        return SELECTED_PATH_CHANGE_NONE;
+    }
+
+    switch (status[0]) {
+        case 'A':
+            return SELECTED_PATH_CHANGE_ADDED;
+        case 'R':
+            return SELECTED_PATH_CHANGE_RENAMED;
+        case 'M':
+        default:
+            return SELECTED_PATH_CHANGE_MODIFIED;
+    }
+}
+
+static int next_nul_terminated_field(const unsigned char* output,
+                                     size_t output_len,
+                                     size_t* start,
+                                     const char** field_out,
+                                     size_t* field_len_out) {
+    size_t end;
+
+    if (!output || !start || !field_out || !field_len_out || *start > output_len) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (*start == output_len) {
+        *field_out = NULL;
+        *field_len_out = 0;
+        return 0;
+    }
+
+    end = *start;
+    while (end < output_len && output[end] != '\0') {
+        end++;
+    }
+    if (end == output_len) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *field_out = (const char*)(output + *start);
+    *field_len_out = end - *start;
+    *start = end + 1;
+    return 1;
+}
+
+static int parse_name_status_output(const unsigned char* output,
+                                    size_t output_len,
+                                    const char* repo_root,
+                                    const char* prefix,
+                                    SelectedPath** paths_out,
+                                    size_t* count_out) {
+    SelectedPath* paths = NULL;
+    size_t count = 0;
+    size_t capacity = 0;
+    size_t start = 0;
+    size_t prefix_len = strlen(prefix);
+    size_t repo_root_len = strlen(repo_root);
+
+    while (start < output_len) {
+        const char* status = NULL;
+        const char* first_path = NULL;
+        const char* second_path = NULL;
+        size_t status_len = 0;
+        size_t first_path_len = 0;
+        size_t second_path_len = 0;
+        int field_status = next_nul_terminated_field(output, output_len, &start, &status, &status_len);
+        if (field_status <= 0) {
+            break;
+        }
+        if (status_len == 0) {
+            continue;
+        }
+        if (next_nul_terminated_field(output, output_len, &start, &first_path, &first_path_len) <= 0 ||
+            first_path_len == 0) {
+            free_selected_paths(paths, count);
+            errno = EINVAL;
+            return -1;
+        }
+
+        SelectedPathChangeType change_type = parse_change_type(status);
+        if (change_type == SELECTED_PATH_CHANGE_RENAMED) {
+            if (next_nul_terminated_field(output, output_len, &start, &second_path, &second_path_len) <= 0 ||
+                second_path_len == 0) {
+                free_selected_paths(paths, count);
+                errno = EINVAL;
+                return -1;
+            }
+            if (append_selected_path(&paths,
+                                     &count,
+                                     &capacity,
+                                     repo_root,
+                                     repo_root_len,
+                                     prefix,
+                                     prefix_len,
+                                     second_path,
+                                     second_path_len,
+                                     change_type,
+                                     first_path) != 0) {
+                free_selected_paths(paths, count);
+                return -1;
+            }
+            continue;
+        }
+
+        if (append_selected_path(&paths,
+                                 &count,
+                                 &capacity,
+                                 repo_root,
+                                 repo_root_len,
+                                 prefix,
+                                 prefix_len,
+                                 first_path,
+                                 first_path_len,
+                                 change_type,
+                                 NULL) != 0) {
+            free_selected_paths(paths, count);
+            return -1;
+        }
     }
 
     if (normalize_selected_paths(paths, &count) != 0) {
@@ -526,7 +700,7 @@ int collect_git_paths(FileSelectionMode mode,
         if (mode == FILE_SELECTION_GIT_STAGED) {
             args[argc++] = "--cached";
         }
-        args[argc++] = "--name-only";
+        args[argc++] = "--name-status";
         args[argc++] = diff_filter;
         if (mode == FILE_SELECTION_GIT_DIFF) {
             args[argc++] = diff_range;
@@ -554,7 +728,9 @@ int collect_git_paths(FileSelectionMode mode,
         goto cleanup;
     }
 
-    if (parse_selected_paths_output(output, output_len, repo_root, prefix, &paths, &parsed_count) != 0) {
+    if ((mode == FILE_SELECTION_GIT_WORKTREE
+            ? parse_name_only_output(output, output_len, repo_root, prefix, &paths, &parsed_count)
+            : parse_name_status_output(output, output_len, repo_root, prefix, &paths, &parsed_count)) != 0) {
         goto cleanup;
     }
 

--- a/src/git_paths.h
+++ b/src/git_paths.h
@@ -5,9 +5,18 @@
 
 #include "app.h"
 
+typedef enum {
+    SELECTED_PATH_CHANGE_NONE = 0,
+    SELECTED_PATH_CHANGE_ADDED,
+    SELECTED_PATH_CHANGE_MODIFIED,
+    SELECTED_PATH_CHANGE_RENAMED
+} SelectedPathChangeType;
+
 typedef struct {
     char* open_path;
     char* display_path;
+    SelectedPathChangeType change_type;
+    char* previous_display_path;
 } SelectedPath;
 
 typedef enum {

--- a/src/main.c
+++ b/src/main.c
@@ -269,6 +269,9 @@ int main(int argc, char* argv[]) {
                                  options.resolved_mode,
                                  repository_name,
                                  generated_at,
+                                 selected_paths,
+                                 selected_count,
+                                 options.diff_range,
                                  ctx.show_tree,
                                  ctx.tree_depth,
                                  &metrics) != 0) {
@@ -348,6 +351,15 @@ int main(int argc, char* argv[]) {
                             repository_name,
                             generated_at) != 0) {
         perror("Error writing output header");
+        goto cleanup;
+    }
+
+    if (write_change_context(output_file,
+                             options.resolved_mode,
+                             selected_paths,
+                             selected_count,
+                             options.diff_range) != 0) {
+        perror("Error writing change context");
         goto cleanup;
     }
 

--- a/src/render.c
+++ b/src/render.c
@@ -85,6 +85,25 @@ static const char* export_mode_label(FileSelectionMode mode) {
     }
 }
 
+static int should_render_change_context(FileSelectionMode mode) {
+    return mode == FILE_SELECTION_GIT_STAGED ||
+           mode == FILE_SELECTION_GIT_UNSTAGED ||
+           mode == FILE_SELECTION_GIT_DIFF;
+}
+
+static const char* change_type_label(SelectedPathChangeType change_type) {
+    switch (change_type) {
+        case SELECTED_PATH_CHANGE_ADDED:
+            return "A";
+        case SELECTED_PATH_CHANGE_RENAMED:
+            return "R";
+        case SELECTED_PATH_CHANGE_MODIFIED:
+        case SELECTED_PATH_CHANGE_NONE:
+        default:
+            return "M";
+    }
+}
+
 static size_t estimate_tokens(size_t byte_count) {
     return (byte_count / 7) * 2 + ((byte_count % 7) * 2) / 7;
 }
@@ -94,7 +113,7 @@ static int write_bytes(FILE* out, const void* data, size_t len) {
 }
 
 static int needs_markdown_escape(unsigned char c) {
-    static const char markdown_meta[] = "\\`*_[]";
+    static const char markdown_meta[] = "\\`*[]";
     return strchr(markdown_meta, c) != NULL;
 }
 
@@ -205,6 +224,65 @@ static int count_export_header_bytes(size_t* total,
     return 0;
 }
 
+static int count_change_context_bytes(size_t* total,
+                                      FileSelectionMode mode,
+                                      const SelectedPath* selected_paths,
+                                      size_t selected_count,
+                                      const char* diff_range) {
+    char count_buf[32];
+
+    if (!total) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!should_render_change_context(mode)) {
+        return 0;
+    }
+    if (snprintf(count_buf, sizeof(count_buf), "%zu", selected_count) < 0) {
+        return -1;
+    }
+
+    if (fuori_count_text_bytes(total, "## Change Context\n\n") != 0 ||
+        fuori_count_text_bytes(total, "Files changed: ") != 0 ||
+        fuori_count_text_bytes(total, count_buf) != 0 ||
+        fuori_count_text_bytes(total, "\n") != 0) {
+        return -1;
+    }
+    if (mode == FILE_SELECTION_GIT_DIFF &&
+        diff_range &&
+        *diff_range != '\0' &&
+        (fuori_count_text_bytes(total, "Diff range: ") != 0 ||
+         fuori_count_text_bytes(total, diff_range) != 0 ||
+         fuori_count_text_bytes(total, "\n") != 0)) {
+        return -1;
+    }
+    if (fuori_count_text_bytes(total, "\n") != 0) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < selected_count; i++) {
+        if (fuori_count_text_bytes(total, "- ") != 0 ||
+            fuori_count_text_bytes(total, change_type_label(selected_paths[i].change_type)) != 0 ||
+            fuori_count_text_bytes(total, " ") != 0) {
+            return -1;
+        }
+        if (selected_paths[i].change_type == SELECTED_PATH_CHANGE_RENAMED &&
+            selected_paths[i].previous_display_path &&
+            *selected_paths[i].previous_display_path != '\0') {
+            if (count_markdown_path_bytes(total, selected_paths[i].previous_display_path) != 0 ||
+                fuori_count_text_bytes(total, " -> ") != 0) {
+                return -1;
+            }
+        }
+        if (count_markdown_path_bytes(total, selected_paths[i].display_path) != 0 ||
+            fuori_count_text_bytes(total, "\n") != 0) {
+            return -1;
+        }
+    }
+
+    return fuori_count_text_bytes(total, "\n");
+}
+
 int write_export_header(FILE* out,
                         FileSelectionMode mode,
                         const char* repository,
@@ -229,6 +307,55 @@ int write_export_header(FILE* out,
     }
 
     return fuori_write_text(out, export_description(mode));
+}
+
+int write_change_context(FILE* out,
+                         FileSelectionMode mode,
+                         const SelectedPath* selected_paths,
+                         size_t selected_count,
+                         const char* diff_range) {
+    if (!out) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!should_render_change_context(mode)) {
+        return 0;
+    }
+
+    if (fprintf(out, "## Change Context\n\nFiles changed: %zu\n", selected_count) < 0) {
+        return -1;
+    }
+    if (mode == FILE_SELECTION_GIT_DIFF &&
+        diff_range &&
+        *diff_range != '\0' &&
+        fprintf(out, "Diff range: %s\n", diff_range) < 0) {
+        return -1;
+    }
+    if (fputc('\n', out) == EOF) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < selected_count; i++) {
+        if (fuori_write_text(out, "- ") != 0 ||
+            fuori_write_text(out, change_type_label(selected_paths[i].change_type)) != 0 ||
+            fuori_write_text(out, " ") != 0) {
+            return -1;
+        }
+        if (selected_paths[i].change_type == SELECTED_PATH_CHANGE_RENAMED &&
+            selected_paths[i].previous_display_path &&
+            *selected_paths[i].previous_display_path != '\0') {
+            if (write_markdown_path(out, selected_paths[i].previous_display_path) != 0 ||
+                fuori_write_text(out, " -> ") != 0) {
+                return -1;
+            }
+        }
+        if (write_markdown_path(out, selected_paths[i].display_path) != 0 ||
+            fuori_write_text(out, "\n") != 0) {
+            return -1;
+        }
+    }
+
+    return fuori_write_text(out, "\n");
 }
 
 static size_t compute_fence_length(const ExportEntry* entry) {
@@ -319,6 +446,9 @@ int calculate_export_metrics(const ExportPlan* plan,
                              FileSelectionMode mode,
                              const char* repository,
                              const char* generated_at,
+                             const SelectedPath* selected_paths,
+                             size_t selected_count,
+                             const char* diff_range,
                              int show_tree,
                              size_t tree_depth,
                              ExportMetrics* metrics) {
@@ -330,6 +460,9 @@ int calculate_export_metrics(const ExportPlan* plan,
     }
 
     if (count_export_header_bytes(&total, mode, repository, generated_at) != 0) {
+        return -1;
+    }
+    if (count_change_context_bytes(&total, mode, selected_paths, selected_count, diff_range) != 0) {
         return -1;
     }
 

--- a/src/render.h
+++ b/src/render.h
@@ -5,6 +5,7 @@
 
 #include "app.h"
 #include "collect.h"
+#include "git_paths.h"
 
 typedef struct {
     size_t files_exported;
@@ -24,6 +25,9 @@ int calculate_export_metrics(const ExportPlan* plan,
                              FileSelectionMode mode,
                              const char* repository,
                              const char* generated_at,
+                             const SelectedPath* selected_paths,
+                             size_t selected_count,
+                             const char* diff_range,
                              int show_tree,
                              size_t tree_depth,
                              ExportMetrics* metrics);
@@ -31,6 +35,11 @@ int write_export_header(FILE* out,
                         FileSelectionMode mode,
                         const char* repository,
                         const char* generated_at);
+int write_change_context(FILE* out,
+                         FileSelectionMode mode,
+                         const SelectedPath* selected_paths,
+                         size_t selected_count,
+                         const char* diff_range);
 int render_export_plan(FILE* out, const ExportPlan* plan, const RenderPlanInfo* info, int verbose);
 
 #endif

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -362,6 +362,7 @@ EOF_IGNORED
 assert_contains "$REPO/sub/stdout.txt" "Repository: repo"
 assert_contains "$REPO/sub/stdout.txt" "Mode: worktree"
 assert_contains "$REPO/sub/stdout.txt" "This document contains tracked files plus untracked, non-ignored files from the current Git subtree."
+assert_not_contains "$REPO/sub/stdout.txt" "## Change Context"
 assert_contains "$REPO/sub/stdout.txt" "├── tracked.c"
 assert_contains "$REPO/sub/stdout.txt" "└── untracked.py"
 assert_not_contains "$REPO/sub/stdout.txt" "ignored.log"
@@ -375,5 +376,84 @@ if (cd "$REPO" && "$BIN" --no-git --staged >/dev/null 2>stderr_invalid.txt); the
     fail "expected --no-git --staged to fail"
 fi
 assert_contains "$REPO/stderr_invalid.txt" "--no-git cannot be combined with --from-stdin, --staged, --unstaged, or --diff"
+
+STAGED_REPO="$TMPDIR/staged_repo"
+mkdir -p "$STAGED_REPO"
+(cd "$STAGED_REPO" && git init -q)
+cat >"$STAGED_REPO/alpha.c" <<'EOF_STAGED_ALPHA_BASE'
+int alpha(void) { return 1; }
+EOF_STAGED_ALPHA_BASE
+cat >"$STAGED_REPO/beta.c" <<'EOF_STAGED_BETA_BASE'
+int beta(void) { return 2; }
+EOF_STAGED_BETA_BASE
+cat >"$STAGED_REPO/old_name.c" <<'EOF_STAGED_OLD_BASE'
+int old_name(void) { return 3; }
+EOF_STAGED_OLD_BASE
+(cd "$STAGED_REPO" && git add alpha.c beta.c old_name.c && \
+    git -c user.name='fuori tests' -c user.email='fuori@example.com' commit -qm base)
+cat >"$STAGED_REPO/alpha.c" <<'EOF_STAGED_ALPHA_MOD'
+int alpha(void) { return 10; }
+EOF_STAGED_ALPHA_MOD
+(cd "$STAGED_REPO" && git add alpha.c)
+(cd "$STAGED_REPO" && git mv old_name.c new_name.c)
+cat >"$STAGED_REPO/added.c" <<'EOF_STAGED_ADDED'
+int added(void) { return 4; }
+EOF_STAGED_ADDED
+(cd "$STAGED_REPO" && git add added.c)
+cat >"$STAGED_REPO/beta.c" <<'EOF_STAGED_BETA_MOD'
+int beta(void) { return 20; }
+EOF_STAGED_BETA_MOD
+
+(cd "$STAGED_REPO" && "$BIN" --staged --no-tree -o - >staged_stdout.txt 2>staged_stderr.txt)
+assert_contains "$STAGED_REPO/staged_stdout.txt" "Mode: staged"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "## Change Context"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "Files changed: 3"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "- A added.c"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "- M alpha.c"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "- R old_name.c -> new_name.c"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "## added.c"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "## alpha.c"
+assert_contains "$STAGED_REPO/staged_stdout.txt" "## new_name.c"
+
+(cd "$STAGED_REPO" && "$BIN" --unstaged --no-tree -o - >unstaged_stdout.txt 2>unstaged_stderr.txt)
+assert_contains "$STAGED_REPO/unstaged_stdout.txt" "Mode: unstaged"
+assert_contains "$STAGED_REPO/unstaged_stdout.txt" "## Change Context"
+assert_contains "$STAGED_REPO/unstaged_stdout.txt" "Files changed: 1"
+assert_contains "$STAGED_REPO/unstaged_stdout.txt" "- M beta.c"
+assert_contains "$STAGED_REPO/unstaged_stdout.txt" "## beta.c"
+assert_not_contains "$STAGED_REPO/unstaged_stdout.txt" "- A added.c"
+
+DIFF_REPO="$TMPDIR/diff_repo"
+mkdir -p "$DIFF_REPO"
+(cd "$DIFF_REPO" && git init -q)
+cat >"$DIFF_REPO/shared.c" <<'EOF_DIFF_SHARED_BASE'
+int shared(void) { return 1; }
+EOF_DIFF_SHARED_BASE
+cat >"$DIFF_REPO/old_name.c" <<'EOF_DIFF_OLD_BASE'
+int old_name(void) { return 2; }
+EOF_DIFF_OLD_BASE
+(cd "$DIFF_REPO" && git add shared.c old_name.c && \
+    git -c user.name='fuori tests' -c user.email='fuori@example.com' commit -qm base)
+(cd "$DIFF_REPO" && git mv old_name.c renamed.c)
+cat >"$DIFF_REPO/shared.c" <<'EOF_DIFF_SHARED_MOD'
+int shared(void) { return 10; }
+EOF_DIFF_SHARED_MOD
+cat >"$DIFF_REPO/fresh.c" <<'EOF_DIFF_FRESH'
+int fresh(void) { return 3; }
+EOF_DIFF_FRESH
+(cd "$DIFF_REPO" && git add renamed.c shared.c fresh.c && \
+    git -c user.name='fuori tests' -c user.email='fuori@example.com' commit -qm update)
+
+(cd "$DIFF_REPO" && "$BIN" --diff HEAD~1..HEAD --no-tree -o - >diff_stdout.txt 2>diff_stderr.txt)
+assert_contains "$DIFF_REPO/diff_stdout.txt" "Mode: diff"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "## Change Context"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "Files changed: 3"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "Diff range: HEAD~1..HEAD"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "- A fresh.c"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "- M shared.c"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "- R old_name.c -> renamed.c"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "## fresh.c"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "## renamed.c"
+assert_contains "$DIFF_REPO/diff_stdout.txt" "## shared.c"
 
 printf 'cli tests passed\n'


### PR DESCRIPTION
### Summary
Add a Change Context section to markdown exports produced with --staged, --unstaged, and --diff.

This gives the export a compact, grounded summary of what changed before the file contents begin.

### Changes
Extend Git-selected path metadata to retain:
- change type (A, M, R)
- previous path for renames

Switch Git change-selection commands to --name-status so change status is preserved

Render a ## Change Context section for:
--staged
--unstaged
--diff
