### PR TITLE
add secret protection for sensitive files

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ fuori [OPTIONS]
 | `-v`, `--verbose` | Show progress during export |
 | `-o`, `--output <path>` | Output path (`-` for stdout) |
 | `--no-clobber` | Fail if output already exists |
+| `--allow-sensitive` | Export files even if they match sensitive-file protection rules |
 | `--no-git` | Force filesystem selection |
 | `--from-stdin` | Read paths from stdin |
 | `--staged` | Export staged files |
@@ -120,6 +121,7 @@ fuori -s 50                        # 50 KB file size cap
 fuori --warn-tokens 100000         # Earlier token warning
 fuori --max-tokens 270000          # Hard token budget
 fuori -o out.md --no-clobber       # Refuse to overwrite
+fuori --allow-sensitive            # Export files that secret protection would skip
 ```
 
 ## Ignore Rules
@@ -151,6 +153,20 @@ To export paths that match the default list, use `--from-stdin`.
 
 Files larger than the specified size limit (default 100KB) are automatically excluded from the export to prevent including large binary or data files. You can change this limit using the `-s` option.
 
+## Sensitive File Protection
+
+By default, `fuori` skips files that look obviously sensitive and prints a warning to `stderr`.
+This protection applies in every selection mode, including Git-backed modes and `--from-stdin`.
+
+v1 checks:
+
+- high-risk filenames such as `.env*`, `credentials*`, `secret*`, `id_rsa*`, `*.pem`, and `*.key`
+- obvious content patterns such as private key blocks and a small set of API key prefixes
+
+Sensitive files are omitted entirely from the Markdown output. In `--staged`, `--unstaged`, and `--diff` mode they are also omitted from `Change Context`.
+
+Use `--allow-sensitive` to disable this protection for a run.
+
 ## Git File Selection
 
 By default, `fuori` asks Git for tracked files plus untracked non-ignored files in the current subtree.
@@ -168,7 +184,7 @@ Additional semantics:
 
 - The default Git-backed mode and explicit Git file-selection modes are scoped to the current working directory subtree when run from a Git subdirectory
 - Git-selected files bypass bypass ignore rules at selection time
-- Git-selected files still go through normal export-time checks such as regular-file validation, symlink skipping, binary detection, size limits, and output-file self-exclusion
+- Git-selected files still go through normal export-time checks such as regular-file validation, symlink skipping, binary detection, size limits, sensitive-file protection, and output-file self-exclusion
 - `--unstaged` does not include untracked files
 - Renamed files are exported under the current path reported by Git
 - `--staged`, `--unstaged`, and `--diff` include a `Change Context` section with change status summaries
@@ -190,7 +206,7 @@ git ls-files -z -- src/ | fuori --from-stdin -0
 Semantics:
 
 - stdin-selected paths bypass selection-time ignore rules
-- they still go through export-time checks such as regular-file validation, symlink skipping, binary detection, size limits, and output-file self-exclusion
+- they still go through export-time checks such as regular-file validation, symlink skipping, binary detection, size limits, sensitive-file protection, and output-file self-exclusion
 - `--from-stdin` is mutually exclusive with `--staged`, `--unstaged`, `--diff`, and `--no-git`
 - `-0` / `--null` requires `--from-stdin`
 - empty stdin is a successful no-op export that still emits the export preamble
@@ -224,6 +240,7 @@ In practice, that means files with NUL bytes, invalid UTF-8, or too many control
 Empty files are skipped.
 Symbolic links are skipped to avoid recursion cycles.
 UTF-16 and other non-UTF-8 text encodings are currently treated as non-exportable and skipped.
+Sensitive files are skipped by default unless `--allow-sensitive` is set.
 
 ## Output Format
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -21,6 +21,7 @@ These implementation choices are worth preserving because they match the tool's 
 - Git integration is pragmatic: `fuori` relies on the system `git` binary instead of a heavier embedded Git library, while still falling back to the filesystem walker outside repositories.
 - Subprocess handling is defensive: Git commands use careful fork/exec handling so `execvp` failures can be reported reliably rather than inferred indirectly.
 - Content filtering is intentionally strict: the collector is biased toward exporting UTF-8-like source text and skipping inputs that are likely to pollute LLM context.
+- Secret protection should stay simple and default-on: block obviously sensitive filenames and a short list of high-signal content patterns, warn generically, and allow an explicit per-run override.
 - Token estimation is artifact-based: warnings and hard limits are derived from the final rendered Markdown structure rather than just raw source bytes.
 - Output handling is atomic: token-limit refusal happens before destination mutation, file output uses `mkstemp` plus `rename`, and temp/final output files are excluded from collection via inode/device checks.
 - Git-backed and filesystem-backed selection stay cleanly separated: auto mode prefers Git and falls back quietly, while explicit Git modes remain hard Git-dependent and preserve subtree scoping.
@@ -61,7 +62,7 @@ The local ignore engine exists to support:
 
 It supports common `.gitignore`-style matching, including recursive `**` globs, but it is not intended to reimplement Git's full layered ignore model.
 
-For stdin-selected paths, the caller chooses the candidate set and the normal export-time gate still applies afterward: regular-file validation, symlink skipping, UTF-8/binary filtering, size limits, output self-exclusion, and deterministic final ordering.
+For stdin-selected paths, the caller chooses the candidate set and the normal export-time gate still applies afterward: regular-file validation, symlink skipping, UTF-8/binary filtering, sensitive-file protection, size limits, output self-exclusion, and deterministic final ordering.
 
 ## Stdin Selection Semantics
 

--- a/src/app.h
+++ b/src/app.h
@@ -20,6 +20,7 @@ typedef struct {
     int no_clobber;
     int output_is_stdout;
     int show_tree;
+    int allow_sensitive;
     size_t max_file_size;
     size_t tree_depth;
     size_t warn_tokens;
@@ -35,6 +36,7 @@ typedef struct {
     size_t skipped_too_large;
     size_t skipped_ignored;
     size_t skipped_symlink;
+    size_t skipped_sensitive;
 } AppContext;
 
 typedef enum {

--- a/src/collect.c
+++ b/src/collect.c
@@ -1,6 +1,7 @@
 #include "collect.h"
 
 #include <dirent.h>
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <fnmatch.h>
@@ -165,6 +166,200 @@ static int is_binary_file(const unsigned char* buffer, size_t bytes_read) {
         }
     }
     return (ctrl * 100 / bytes_read) > 2;
+}
+
+static int equals_ignore_case_char(unsigned char lhs, unsigned char rhs) {
+    return tolower(lhs) == tolower(rhs);
+}
+
+static int starts_with_ignore_case(const char* text, const char* prefix) {
+    if (!text || !prefix) return 0;
+    while (*prefix != '\0') {
+        if (*text == '\0' || !equals_ignore_case_char((unsigned char)*text, (unsigned char)*prefix)) {
+            return 0;
+        }
+        text++;
+        prefix++;
+    }
+    return 1;
+}
+
+static int equals_ignore_case(const char* lhs, const char* rhs) {
+    if (!lhs || !rhs) return 0;
+    while (*lhs != '\0' && *rhs != '\0') {
+        if (!equals_ignore_case_char((unsigned char)*lhs, (unsigned char)*rhs)) {
+            return 0;
+        }
+        lhs++;
+        rhs++;
+    }
+    return *lhs == '\0' && *rhs == '\0';
+}
+
+static int ends_with_ignore_case(const char* text, const char* suffix) {
+    size_t text_len;
+    size_t suffix_len;
+
+    if (!text || !suffix) return 0;
+    text_len = strlen(text);
+    suffix_len = strlen(suffix);
+    if (suffix_len > text_len) return 0;
+    return equals_ignore_case(text + text_len - suffix_len, suffix);
+}
+
+static int is_sensitive_basename_match(const char* basename,
+                                       const char* prefix,
+                                       int allow_dot_suffix) {
+    size_t prefix_len;
+
+    if (!basename || !prefix) return 0;
+    if (!starts_with_ignore_case(basename, prefix)) {
+        return 0;
+    }
+    prefix_len = strlen(prefix);
+    if (basename[prefix_len] == '\0') {
+        return 1;
+    }
+    return allow_dot_suffix && basename[prefix_len] == '.';
+}
+
+static int is_sensitive_filename(const char* filepath) {
+    const char* basename = filepath;
+    const char* slash = strrchr(filepath, '/');
+
+    if (!filepath) {
+        return 0;
+    }
+    if (slash) {
+        basename = slash + 1;
+    }
+
+    if (equals_ignore_case(basename, ".env") ||
+        starts_with_ignore_case(basename, ".env.") ||
+        is_sensitive_basename_match(basename, "credential", 1) ||
+        is_sensitive_basename_match(basename, "credentials", 1) ||
+        is_sensitive_basename_match(basename, "secret", 1) ||
+        is_sensitive_basename_match(basename, "secrets", 1) ||
+        is_sensitive_basename_match(basename, "id_rsa", 1) ||
+        is_sensitive_basename_match(basename, "id_dsa", 1) ||
+        is_sensitive_basename_match(basename, "id_ecdsa", 1) ||
+        is_sensitive_basename_match(basename, "id_ed25519", 1) ||
+        ends_with_ignore_case(basename, ".pem") ||
+        ends_with_ignore_case(basename, ".key")) {
+        return 1;
+    }
+
+    return 0;
+}
+
+static int buffer_contains_literal(const unsigned char* buffer,
+                                   size_t bytes_read,
+                                   const char* needle) {
+    size_t needle_len;
+
+    if (!buffer || !needle) {
+        return 0;
+    }
+    needle_len = strlen(needle);
+    if (needle_len == 0 || needle_len > bytes_read) {
+        return 0;
+    }
+
+    for (size_t i = 0; i + needle_len <= bytes_read; i++) {
+        if (memcmp(buffer + i, needle, needle_len) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int is_upper_alnum(unsigned char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+}
+
+static int is_openai_key_char(unsigned char c) {
+    return (c >= 'A' && c <= 'Z') ||
+           (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') ||
+           c == '-' ||
+           c == '_';
+}
+
+static int buffer_contains_prefixed_run(const unsigned char* buffer,
+                                        size_t bytes_read,
+                                        const char* prefix,
+                                        size_t required_run_len,
+                                        int (*char_ok)(unsigned char)) {
+    size_t prefix_len;
+
+    if (!buffer || !prefix || !char_ok) {
+        return 0;
+    }
+    prefix_len = strlen(prefix);
+    if (prefix_len == 0 || prefix_len + required_run_len > bytes_read) {
+        return 0;
+    }
+
+    for (size_t i = 0; i + prefix_len + required_run_len <= bytes_read; i++) {
+        if (memcmp(buffer + i, prefix, prefix_len) != 0) {
+            continue;
+        }
+        size_t run_len = 0;
+        while (i + prefix_len + run_len < bytes_read &&
+               char_ok(buffer[i + prefix_len + run_len])) {
+            run_len++;
+        }
+        if (run_len >= required_run_len) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int contains_sensitive_content(const unsigned char* buffer, size_t bytes_read) {
+    static const char* private_key_markers[] = {
+        "-----BEGIN PRIVATE KEY-----",
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "-----BEGIN OPENSSH PRIVATE KEY-----",
+        "-----BEGIN EC PRIVATE KEY-----",
+        "-----BEGIN DSA PRIVATE KEY-----",
+        "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+        NULL
+    };
+    static const char* github_prefixes[] = {
+        "ghp_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        NULL
+    };
+
+    if (!buffer) {
+        return 0;
+    }
+
+    for (size_t i = 0; private_key_markers[i] != NULL; i++) {
+        if (buffer_contains_literal(buffer, bytes_read, private_key_markers[i])) {
+            return 1;
+        }
+    }
+    if (buffer_contains_prefixed_run(buffer, bytes_read, "AKIA", 16, is_upper_alnum) ||
+        buffer_contains_prefixed_run(buffer, bytes_read, "ASIA", 16, is_upper_alnum)) {
+        return 1;
+    }
+    for (size_t i = 0; github_prefixes[i] != NULL; i++) {
+        if (buffer_contains_prefixed_run(buffer, bytes_read, github_prefixes[i], 20, is_openai_key_char)) {
+            return 1;
+        }
+    }
+    if (buffer_contains_prefixed_run(buffer, bytes_read, "sk-", 20, is_openai_key_char)) {
+        return 1;
+    }
+
+    return 0;
 }
 
 static const char* classify_shebang_interpreter(const char* name) {
@@ -509,6 +704,12 @@ static int collect_exportable_file(const char* open_path,
         return 0;
     }
 
+    if (!ctx->allow_sensitive && is_sensitive_filename(open_path)) {
+        ctx->skipped_sensitive++;
+        fprintf(stderr, "Warning: Skipping sensitive file %s\n", display_path);
+        return 0;
+    }
+
     /* Cache accepted file contents in memory to avoid re-reading at render time. */
     int read_result = read_file_buffer(open_path, st, ctx->max_file_size, &buffer, &bytes_read);
     if (read_result == 1) {
@@ -535,6 +736,12 @@ static int collect_exportable_file(const char* open_path,
         if (ctx->verbose) {
             fprintf(stderr, "Skipping binary/empty file: %s\n", display_path);
         }
+        free(buffer);
+        return 0;
+    }
+    if (!ctx->allow_sensitive && contains_sensitive_content(buffer, bytes_read)) {
+        ctx->skipped_sensitive++;
+        fprintf(stderr, "Warning: Skipping sensitive file %s\n", display_path);
         free(buffer);
         return 0;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -86,6 +86,7 @@ static void print_verbose_skip_summary(const AppContext* ctx) {
     char large_buf[32];
     char ignored_buf[32];
     char symlink_buf[32];
+    char sensitive_buf[32];
 
     if (!ctx || !ctx->verbose) {
         return;
@@ -94,22 +95,25 @@ static void print_verbose_skip_summary(const AppContext* ctx) {
     if (format_size_with_commas(ctx->skipped_binary, binary_buf, sizeof(binary_buf)) != 0 ||
         format_size_with_commas(ctx->skipped_too_large, large_buf, sizeof(large_buf)) != 0 ||
         format_size_with_commas(ctx->skipped_ignored, ignored_buf, sizeof(ignored_buf)) != 0 ||
-        format_size_with_commas(ctx->skipped_symlink, symlink_buf, sizeof(symlink_buf)) != 0) {
+        format_size_with_commas(ctx->skipped_symlink, symlink_buf, sizeof(symlink_buf)) != 0 ||
+        format_size_with_commas(ctx->skipped_sensitive, sensitive_buf, sizeof(sensitive_buf)) != 0) {
         fprintf(stderr,
-                "Skipped: binary/empty=%zu, too_large=%zu, ignored=%zu, symlink=%zu\n",
+                "Skipped: binary/empty=%zu, too_large=%zu, ignored=%zu, symlink=%zu, sensitive=%zu\n",
                 ctx->skipped_binary,
                 ctx->skipped_too_large,
                 ctx->skipped_ignored,
-                ctx->skipped_symlink);
+                ctx->skipped_symlink,
+                ctx->skipped_sensitive);
         return;
     }
 
     fprintf(stderr,
-            "Skipped: binary/empty=%s, too_large=%s, ignored=%s, symlink=%s\n",
+            "Skipped: binary/empty=%s, too_large=%s, ignored=%s, symlink=%s, sensitive=%s\n",
             binary_buf,
             large_buf,
             ignored_buf,
-            symlink_buf);
+            symlink_buf,
+            sensitive_buf);
 }
 
 static int make_temp_output_template(const char* output_path, char* tmpl, size_t tmpl_size) {
@@ -170,6 +174,65 @@ static int format_generated_timestamp(char* buffer, size_t buffer_size) {
     return 0;
 }
 
+static const char* normalize_display_path(const char* path) {
+    if (path && strncmp(path, "./", 2) == 0) {
+        return path + 2;
+    }
+    return path;
+}
+
+static int export_plan_contains_selected_path(const ExportPlan* plan, const SelectedPath* selected_path) {
+    const char* selected_display;
+
+    if (!plan || !selected_path) {
+        return 0;
+    }
+    selected_display = normalize_display_path(selected_path->display_path);
+
+    for (size_t i = 0; i < plan->count; i++) {
+        const ExportEntry* entry = &plan->entries[i];
+        if (strcmp(entry->open_path, selected_path->open_path) == 0 &&
+            strcmp(entry->display_path, selected_display ? selected_display : selected_path->open_path) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static void compact_selected_paths_to_export_plan(SelectedPath* selected_paths,
+                                                  size_t* selected_count,
+                                                  const ExportPlan* plan) {
+    size_t write_index = 0;
+
+    if (!selected_count || !selected_paths || !plan) {
+        return;
+    }
+
+    for (size_t read_index = 0; read_index < *selected_count; read_index++) {
+        SelectedPath* path = &selected_paths[read_index];
+        if (export_plan_contains_selected_path(plan, path)) {
+            if (write_index != read_index) {
+                selected_paths[write_index] = *path;
+                path->open_path = NULL;
+                path->display_path = NULL;
+                path->previous_display_path = NULL;
+            }
+            write_index++;
+            continue;
+        }
+
+        free(path->open_path);
+        free(path->display_path);
+        free(path->previous_display_path);
+        path->open_path = NULL;
+        path->display_path = NULL;
+        path->previous_display_path = NULL;
+    }
+
+    *selected_count = write_index;
+}
+
 int main(int argc, char* argv[]) {
     CliOptions options;
     AppContext ctx = {0};
@@ -206,6 +269,7 @@ int main(int argc, char* argv[]) {
     ctx.no_clobber = options.no_clobber;
     ctx.output_is_stdout = options.output_is_stdout;
     ctx.show_tree = options.show_tree;
+    ctx.allow_sensitive = options.allow_sensitive;
     ctx.max_file_size = options.max_file_size;
     ctx.tree_depth = options.tree_depth;
     ctx.warn_tokens = options.warn_tokens;
@@ -248,6 +312,7 @@ int main(int argc, char* argv[]) {
             fprintf(stderr, "Error collecting selected files\n");
             goto cleanup;
         }
+        compact_selected_paths_to_export_plan(selected_paths, &selected_count, &plan);
     }
 
     if (prepare_render_plan(&plan, &render_info) != 0) {

--- a/src/options.c
+++ b/src/options.c
@@ -62,6 +62,7 @@ void print_usage(const char* argv0) {
     printf("  -v, --verbose       Show progress information\n");
     printf("  -o, --output        Set output path (use '-' for stdout)\n");
     printf("      --no-clobber    Fail if output file already exists\n");
+    printf("      --allow-sensitive Export files even if they match sensitive-file protection rules\n");
     printf("      --no-git        Force recursive filesystem selection instead of auto Git detection\n");
     printf("      --from-stdin    Read paths from stdin instead of using Git or filesystem selection\n");
     printf("      --staged        Export staged files from the current Git subtree\n");
@@ -138,6 +139,8 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
             options->stdin_null_delim = 1;
         } else if (strcmp(argv[i], "--no-clobber") == 0) {
             options->no_clobber = 1;
+        } else if (strcmp(argv[i], "--allow-sensitive") == 0) {
+            options->allow_sensitive = 1;
         } else if (strcmp(argv[i], "--tree") == 0) {
             options->show_tree = 1;
         } else if (strcmp(argv[i], "--no-tree") == 0) {

--- a/src/options.h
+++ b/src/options.h
@@ -12,6 +12,7 @@ typedef struct {
     int output_is_stdout;
     int stdin_null_delim;
     int show_tree;
+    int allow_sensitive;
     size_t max_file_size;
     size_t tree_depth;
     size_t warn_tokens;

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -64,6 +64,10 @@ assert_occurrences() {
 TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/fuori-cli-test.XXXXXX")
 trap 'rm -rf "$TMPDIR"' EXIT INT TERM
 
+(cd "$BIN_DIR" && "$BIN" --help >"$TMPDIR/help_stdout.txt" 2>"$TMPDIR/help_stderr.txt")
+assert_contains "$TMPDIR/help_stdout.txt" "--allow-sensitive"
+assert_file_equals "$TMPDIR/help_stderr.txt" ""
+
 OUTSIDE="$TMPDIR/outside"
 mkdir -p "$OUTSIDE"
 cat >"$OUTSIDE/main.c" <<'EOF_OUTSIDE'
@@ -111,7 +115,42 @@ awk 'BEGIN { for (i = 0; i < 2048; i++) printf "x"; printf "\n" }' >"$VERBOSE_DI
 ln -s main.c "$VERBOSE_DIR/link.c"
 
 (cd "$VERBOSE_DIR" && "$BIN" -v -s 1 -o - >verbose_stdout.txt 2>verbose_stderr.txt)
-assert_contains "$VERBOSE_DIR/verbose_stderr.txt" "Skipped: binary/empty=1, too_large=1, ignored=1, symlink=1"
+assert_contains "$VERBOSE_DIR/verbose_stderr.txt" "Skipped: binary/empty=1, too_large=1, ignored=1, symlink=1, sensitive=0"
+
+SENSITIVE_NAME_DIR="$TMPDIR/sensitive_name"
+mkdir -p "$SENSITIVE_NAME_DIR"
+cat >"$SENSITIVE_NAME_DIR/main.c" <<'EOF_SENSITIVE_NAME_MAIN'
+int main(void) { return 0; }
+EOF_SENSITIVE_NAME_MAIN
+cat >"$SENSITIVE_NAME_DIR/credentials.txt" <<'EOF_SENSITIVE_NAME_SECRET'
+plain text but sensitive by filename
+EOF_SENSITIVE_NAME_SECRET
+(cd "$SENSITIVE_NAME_DIR" && "$BIN" --no-git -o - >sensitive_name_stdout.txt 2>"$TMPDIR/sensitive_name_stderr.txt")
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## main.c"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "credentials.txt"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credentials.txt"
+
+(cd "$SENSITIVE_NAME_DIR" && "$BIN" --no-git --allow-sensitive -o - >sensitive_name_allow_stdout.txt 2>"$TMPDIR/sensitive_name_allow_stderr.txt")
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## credentials.txt"
+assert_not_contains "$TMPDIR/sensitive_name_allow_stderr.txt" "Warning: Skipping sensitive file"
+
+SENSITIVE_CONTENT_DIR="$TMPDIR/sensitive_content"
+mkdir -p "$SENSITIVE_CONTENT_DIR"
+cat >"$SENSITIVE_CONTENT_DIR/main.c" <<'EOF_SENSITIVE_CONTENT_MAIN'
+int main(void) { return 0; }
+EOF_SENSITIVE_CONTENT_MAIN
+cat >"$SENSITIVE_CONTENT_DIR/notes.txt" <<'EOF_SENSITIVE_CONTENT_SECRET'
+api_key=sk-abcdefghijklmnopqrstuvwxyz123456
+EOF_SENSITIVE_CONTENT_SECRET
+(cd "$SENSITIVE_CONTENT_DIR" && "$BIN" --no-git -o - >sensitive_content_stdout.txt 2>"$TMPDIR/sensitive_content_stderr.txt")
+assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## main.c"
+assert_not_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## notes.txt"
+assert_contains "$TMPDIR/sensitive_content_stderr.txt" "Warning: Skipping sensitive file ./notes.txt"
+assert_not_contains "$TMPDIR/sensitive_content_stderr.txt" "sk-abcdefghijklmnopqrstuvwxyz123456"
+
+(cd "$SENSITIVE_CONTENT_DIR" && "$BIN" --no-git --allow-sensitive -o - >sensitive_content_allow_stdout.txt 2>"$TMPDIR/sensitive_content_allow_stderr.txt")
+assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_allow_stdout.txt" "## notes.txt"
+assert_not_contains "$TMPDIR/sensitive_content_allow_stderr.txt" "Warning: Skipping sensitive file"
 
 (cd "$OUTSIDE" && "$BIN" -v -o verbose_export.md >verbose_file_stdout.txt 2>verbose_file_stderr.txt)
 assert_file_equals "$OUTSIDE/verbose_file_stdout.txt" ""
@@ -422,6 +461,30 @@ assert_contains "$STAGED_REPO/unstaged_stdout.txt" "Files changed: 1"
 assert_contains "$STAGED_REPO/unstaged_stdout.txt" "- M beta.c"
 assert_contains "$STAGED_REPO/unstaged_stdout.txt" "## beta.c"
 assert_not_contains "$STAGED_REPO/unstaged_stdout.txt" "- A added.c"
+
+SENSITIVE_STAGED_REPO="$TMPDIR/sensitive_staged_repo"
+mkdir -p "$SENSITIVE_STAGED_REPO"
+(cd "$SENSITIVE_STAGED_REPO" && git init -q)
+cat >"$SENSITIVE_STAGED_REPO/safe.c" <<'EOF_SENSITIVE_STAGED_BASE'
+int safe(void) { return 1; }
+EOF_SENSITIVE_STAGED_BASE
+(cd "$SENSITIVE_STAGED_REPO" && git add safe.c && \
+    git -c user.name='fuori tests' -c user.email='fuori@example.com' commit -qm base)
+cat >"$SENSITIVE_STAGED_REPO/safe.c" <<'EOF_SENSITIVE_STAGED_MOD'
+int safe(void) { return 2; }
+EOF_SENSITIVE_STAGED_MOD
+cat >"$SENSITIVE_STAGED_REPO/credentials.txt" <<'EOF_SENSITIVE_STAGED_SECRET'
+do not export me
+EOF_SENSITIVE_STAGED_SECRET
+(cd "$SENSITIVE_STAGED_REPO" && git add safe.c credentials.txt)
+
+(cd "$SENSITIVE_STAGED_REPO" && "$BIN" --staged --no-tree -o - >sensitive_staged_stdout.txt 2>sensitive_staged_stderr.txt)
+assert_contains "$SENSITIVE_STAGED_REPO/sensitive_staged_stdout.txt" "## Change Context"
+assert_contains "$SENSITIVE_STAGED_REPO/sensitive_staged_stdout.txt" "Files changed: 1"
+assert_contains "$SENSITIVE_STAGED_REPO/sensitive_staged_stdout.txt" "- M safe.c"
+assert_contains "$SENSITIVE_STAGED_REPO/sensitive_staged_stdout.txt" "## safe.c"
+assert_not_contains "$SENSITIVE_STAGED_REPO/sensitive_staged_stdout.txt" "credentials.txt"
+assert_contains "$SENSITIVE_STAGED_REPO/sensitive_staged_stderr.txt" "Warning: Skipping sensitive file credentials.txt"
 
 DIFF_REPO="$TMPDIR/diff_repo"
 mkdir -p "$DIFF_REPO"


### PR DESCRIPTION
## Summary
Add default-on secret protection to `fuori` so obviously sensitive files are excluded from exports unless the user explicitly opts in.

## Changes
- Add `--allow-sensitive` to bypass secret protection for a run
- Skip sensitive files by default and print a generic warning to `stderr`
- Add filename-based screening for obvious high-risk files such as:
  - `.env*`
  - `credentials*`
  - `secret*`
  - `id_rsa*`, `id_dsa*`, `id_ecdsa*`, `id_ed25519*`
  - `*.pem`
  - `*.key`
- Add content-based screening for obvious secret material such as:
  - private key block headers
  - AWS-style access key IDs
  - GitHub token prefixes
  - OpenAI-style `sk-` keys
- Add `skipped_sensitive` tracking to verbose skip summaries
- Ensure sensitive files are omitted from `Change Context` in `--staged`, `--unstaged`, and `--diff`
- Update README and `docs/design.md` with the new behavior
- Add CLI coverage for:
  - help output
  - filename-based blocking
  - content-based blocking
  - `--allow-sensitive`
  - warning redaction
  - staged change-context omission

## Behavior
- Secret protection applies in all selection modes, including `--from-stdin`
- Sensitive files are omitted entirely from the markdown output
- Warnings do not include matched secret values
- `--allow-sensitive` disables both filename-based and content-based protection

## Verification
- Ran `make test` successfully