### PR TITLE
reject no-default-ignore outside filesystem mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ fuori [OPTIONS]
 | `--allow-sensitive` | Export files even if they match sensitive-file protection rules |
 
 Git selection flags (`--staged`, `--unstaged`, `--diff`) and `--from-stdin` are mutually exclusive; `--no-git` cannot be combined with them.
+`--no-default-ignore` only applies to filesystem selection.
 
 **Examples:**
 

--- a/src/options.c
+++ b/src/options.c
@@ -37,6 +37,11 @@ static void print_selection_mode_conflict(void) {
     fprintf(stderr, "Use -h or --help for usage information\n");
 }
 
+static void print_no_default_ignore_conflict(void) {
+    fprintf(stderr, "--no-default-ignore can only be used with filesystem selection\n");
+    fprintf(stderr, "Use -h or --help for usage information\n");
+}
+
 void init_cli_options(CliOptions* options) {
     if (!options) {
         return;
@@ -251,6 +256,15 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
     if (options->stdin_null_delim && options->requested_mode != FILE_SELECTION_STDIN) {
         fprintf(stderr, "-0/--null requires --from-stdin\n");
         fprintf(stderr, "Use -h or --help for usage information\n");
+        return -1;
+    }
+
+    if (options->no_default_ignore &&
+        (options->requested_mode == FILE_SELECTION_STDIN ||
+         options->requested_mode == FILE_SELECTION_GIT_STAGED ||
+         options->requested_mode == FILE_SELECTION_GIT_UNSTAGED ||
+         options->requested_mode == FILE_SELECTION_GIT_DIFF)) {
+        print_no_default_ignore_conflict();
         return -1;
     }
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -370,6 +370,11 @@ if printf 'alpha.c\n' | (cd "$STDIN_DIR" && "$BIN" --from-stdin --no-git >/dev/n
 fi
 assert_contains "$STDIN_DIR/stdin_conflict_no_git.txt" "--no-git cannot be combined with --from-stdin, --staged, --unstaged, or --diff"
 
+if printf 'alpha.c\n' | (cd "$STDIN_DIR" && "$BIN" --from-stdin --no-default-ignore >/dev/null 2>stdin_conflict_no_default_ignore.txt); then
+    fail "expected --from-stdin --no-default-ignore to fail"
+fi
+assert_contains "$STDIN_DIR/stdin_conflict_no_default_ignore.txt" "--no-default-ignore can only be used with filesystem selection"
+
 if (cd "$STDIN_DIR" && "$BIN" -0 >/dev/null 2>stdin_null_without_mode_stderr.txt); then
     fail "expected -0 without --from-stdin to fail"
 fi
@@ -457,6 +462,11 @@ if (cd "$REPO" && "$BIN" --no-git --staged >/dev/null 2>stderr_invalid.txt); the
     fail "expected --no-git --staged to fail"
 fi
 assert_contains "$REPO/stderr_invalid.txt" "--no-git cannot be combined with --from-stdin, --staged, --unstaged, or --diff"
+
+if (cd "$REPO" && "$BIN" --staged --no-default-ignore >/dev/null 2>stderr_no_default_ignore_invalid.txt); then
+    fail "expected --staged --no-default-ignore to fail"
+fi
+assert_contains "$REPO/stderr_no_default_ignore_invalid.txt" "--no-default-ignore can only be used with filesystem selection"
 
 STAGED_REPO="$TMPDIR/staged_repo"
 mkdir -p "$STAGED_REPO"


### PR DESCRIPTION
## Summary
Make `--no-default-ignore` behave honestly by rejecting it outside filesystem selection.

## Changes
- Reject `--no-default-ignore` when used with:
  - `--from-stdin`
  - `--staged`
  - `--unstaged`
  - `--diff`
- Add a dedicated CLI error message explaining that the flag only applies to filesystem selection
- Update the README to state that constraint explicitly
- Add CLI coverage for both stdin-backed and Git-backed misuse cases

## Why
`--no-default-ignore` only affects the recursive/filesystem path. Before this change, the CLI accepted it in explicit non-filesystem modes as a silent no-op, which made the contract less trustworthy. Rejecting it is more consistent with the rest of `fuori`’s flag validation style.

## Verification
- Ran `make test` successfully