### PR TITLE
harden export filtering and release versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build
-        run: make
+        run: make VERSION="${GITHUB_REF_NAME}"
 
       - name: Package
         run: tar -czf "${{ matrix.asset }}" fuori README.md LICENSE

--- a/src/collect.c
+++ b/src/collect.c
@@ -207,20 +207,9 @@ static int ends_with_ignore_case(const char* text, const char* suffix) {
     return equals_ignore_case(text + text_len - suffix_len, suffix);
 }
 
-static int is_sensitive_basename_match(const char* basename,
-                                       const char* prefix,
-                                       int allow_dot_suffix) {
-    size_t prefix_len;
-
+static int is_sensitive_basename_prefix(const char* basename, const char* prefix) {
     if (!basename || !prefix) return 0;
-    if (!starts_with_ignore_case(basename, prefix)) {
-        return 0;
-    }
-    prefix_len = strlen(prefix);
-    if (basename[prefix_len] == '\0') {
-        return 1;
-    }
-    return allow_dot_suffix && basename[prefix_len] == '.';
+    return starts_with_ignore_case(basename, prefix);
 }
 
 static int is_sensitive_filename(const char* filepath) {
@@ -234,16 +223,15 @@ static int is_sensitive_filename(const char* filepath) {
         basename = slash + 1;
     }
 
-    if (equals_ignore_case(basename, ".env") ||
-        starts_with_ignore_case(basename, ".env.") ||
-        is_sensitive_basename_match(basename, "credential", 1) ||
-        is_sensitive_basename_match(basename, "credentials", 1) ||
-        is_sensitive_basename_match(basename, "secret", 1) ||
-        is_sensitive_basename_match(basename, "secrets", 1) ||
-        is_sensitive_basename_match(basename, "id_rsa", 1) ||
-        is_sensitive_basename_match(basename, "id_dsa", 1) ||
-        is_sensitive_basename_match(basename, "id_ecdsa", 1) ||
-        is_sensitive_basename_match(basename, "id_ed25519", 1) ||
+    if (is_sensitive_basename_prefix(basename, ".env") ||
+        is_sensitive_basename_prefix(basename, "credential") ||
+        is_sensitive_basename_prefix(basename, "credentials") ||
+        is_sensitive_basename_prefix(basename, "secret") ||
+        is_sensitive_basename_prefix(basename, "secrets") ||
+        is_sensitive_basename_prefix(basename, "id_rsa") ||
+        is_sensitive_basename_prefix(basename, "id_dsa") ||
+        is_sensitive_basename_prefix(basename, "id_ecdsa") ||
+        is_sensitive_basename_prefix(basename, "id_ed25519") ||
         ends_with_ignore_case(basename, ".pem") ||
         ends_with_ignore_case(basename, ".key")) {
         return 1;
@@ -775,6 +763,11 @@ static int collect_recursive_paths(const char* base_path,
 
     dir = opendir(base_path);
     if (!dir) {
+        if (strcmp(base_path, ".") != 0 &&
+            (errno == EACCES || errno == EPERM)) {
+            fprintf(stderr, "Warning: Failed to process directory %s\n", base_path);
+            return 0;
+        }
         perror("Error opening directory");
         return -1;
     }

--- a/src/tree.c
+++ b/src/tree.c
@@ -188,6 +188,39 @@ static int tree_add_path(TreeNode* root, const char* display_path) {
     }
 
     TreeNode* current = root;
+    if (display_path[0] == '/') {
+        TreeNode* absolute_root = NULL;
+
+        for (size_t i = 0; i < current->child_count; i++) {
+            if (strcmp(current->children[i]->name, "/") == 0) {
+                absolute_root = current->children[i];
+                break;
+            }
+        }
+
+        if (!absolute_root) {
+            if (current->child_count == current->child_capacity) {
+                size_t new_capacity = (current->child_capacity == 0) ? 8 : current->child_capacity * 2;
+                TreeNode** new_children = realloc(current->children, new_capacity * sizeof(*new_children));
+                if (!new_children) {
+                    free(path_copy);
+                    return -1;
+                }
+                current->children = new_children;
+                current->child_capacity = new_capacity;
+            }
+
+            absolute_root = tree_node_create("/", 1);
+            if (!absolute_root) {
+                free(path_copy);
+                return -1;
+            }
+            current->children[current->child_count++] = absolute_root;
+        }
+
+        current = absolute_root;
+    }
+
     char* saveptr = NULL;
     char* token = strtok_r(path_copy, "/", &saveptr);
     while (token) {

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -142,13 +142,37 @@ EOF_SENSITIVE_NAME_MAIN
 cat >"$SENSITIVE_NAME_DIR/credentials.txt" <<'EOF_SENSITIVE_NAME_SECRET'
 plain text but sensitive by filename
 EOF_SENSITIVE_NAME_SECRET
+cat >"$SENSITIVE_NAME_DIR/.envrc" <<'EOF_SENSITIVE_NAME_ENVRC'
+export TOKEN=1
+EOF_SENSITIVE_NAME_ENVRC
+cat >"$SENSITIVE_NAME_DIR/credentials-prod.txt" <<'EOF_SENSITIVE_NAME_CREDENTIALS_DASH'
+prod credentials
+EOF_SENSITIVE_NAME_CREDENTIALS_DASH
+cat >"$SENSITIVE_NAME_DIR/secret_backup" <<'EOF_SENSITIVE_NAME_SECRET_BACKUP'
+backup secret
+EOF_SENSITIVE_NAME_SECRET_BACKUP
+cat >"$SENSITIVE_NAME_DIR/id_rsa_backup" <<'EOF_SENSITIVE_NAME_ID_RSA_BACKUP'
+backup ssh key
+EOF_SENSITIVE_NAME_ID_RSA_BACKUP
 (cd "$SENSITIVE_NAME_DIR" && "$BIN" --no-git -o - >sensitive_name_stdout.txt 2>"$TMPDIR/sensitive_name_stderr.txt")
 assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## main.c"
 assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "credentials.txt"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" ".envrc"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "credentials-prod.txt"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "secret_backup"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "id_rsa_backup"
 assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credentials.txt"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./.envrc"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credentials-prod.txt"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./secret_backup"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./id_rsa_backup"
 
 (cd "$SENSITIVE_NAME_DIR" && "$BIN" --no-git --allow-sensitive -o - >sensitive_name_allow_stdout.txt 2>"$TMPDIR/sensitive_name_allow_stderr.txt")
 assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## credentials.txt"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## .envrc"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## credentials-prod.txt"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## secret_backup"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## id_rsa_backup"
 assert_not_contains "$TMPDIR/sensitive_name_allow_stderr.txt" "Warning: Skipping sensitive file"
 
 SENSITIVE_CONTENT_DIR="$TMPDIR/sensitive_content"
@@ -252,6 +276,23 @@ if [ "$(id -u)" -ne 0 ]; then
     assert_contains "$PERM_DIR/permission_stdout.txt" "## main.c"
     assert_not_contains "$PERM_DIR/permission_stdout.txt" "private.txt"
     assert_contains "$PERM_DIR/permission_stderr.txt" "Warning: Failed to process file ./private.txt"
+fi
+
+UNREADABLE_DIR="$TMPDIR/unreadable_directory"
+mkdir -p "$UNREADABLE_DIR/blocked"
+cat >"$UNREADABLE_DIR/main.c" <<'EOF_UNREADABLE_DIR_MAIN'
+int main(void) { return 0; }
+EOF_UNREADABLE_DIR_MAIN
+cat >"$UNREADABLE_DIR/blocked/hidden.c" <<'EOF_UNREADABLE_DIR_HIDDEN'
+int hidden(void) { return 0; }
+EOF_UNREADABLE_DIR_HIDDEN
+if [ "$(id -u)" -ne 0 ]; then
+    chmod 000 "$UNREADABLE_DIR/blocked"
+    (cd "$UNREADABLE_DIR" && "$BIN" --no-git --no-tree -o - >unreadable_dir_stdout.txt 2>unreadable_dir_stderr.txt)
+    chmod 700 "$UNREADABLE_DIR/blocked"
+    assert_contains "$UNREADABLE_DIR/unreadable_dir_stdout.txt" "## main.c"
+    assert_not_contains "$UNREADABLE_DIR/unreadable_dir_stdout.txt" "hidden.c"
+    assert_contains "$UNREADABLE_DIR/unreadable_dir_stderr.txt" "Warning: Failed to process directory ./blocked"
 fi
 
 ODD_DIR="$TMPDIR/odd_paths"
@@ -402,6 +443,12 @@ assert_contains "$STDIN_DIR/stdin_spaces_newline_stdout.txt" "## file with space
 
 printf 'file with spaces.txt\0' | (cd "$STDIN_DIR" && "$BIN" --from-stdin --null --no-tree -o - >stdin_spaces_null_stdout.txt 2>stdin_spaces_null_stderr.txt)
 assert_contains "$STDIN_DIR/stdin_spaces_null_stdout.txt" "## file with spaces.txt"
+
+ABS_STDIN_PATH=$(cd "$STDIN_DIR" && pwd)/alpha.c
+printf '%s\n' "$ABS_STDIN_PATH" | (cd "$STDIN_DIR" && "$BIN" --from-stdin -o - >stdin_absolute_stdout.txt 2>stdin_absolute_stderr.txt)
+assert_contains "$STDIN_DIR/stdin_absolute_stdout.txt" "## $ABS_STDIN_PATH"
+assert_contains "$STDIN_DIR/stdin_absolute_stdout.txt" "└── /"
+assert_contains "$STDIN_DIR/stdin_absolute_stdout.txt" "└── alpha.c"
 
 printf 'beta.c\nalpha.c\n' | (cd "$STDIN_DIR" && "$BIN" --from-stdin --no-tree -o - >stdin_order_stdout.txt 2>stdin_order_stderr.txt)
 first_heading=$(grep '^## ' "$STDIN_DIR/stdin_order_stdout.txt" | head -n 1)


### PR DESCRIPTION
## Summary
Fix the issues around sensitive-file detection, recursive filesystem robustness, absolute stdin tree rendering, and release version stamping.

## Changes
- Broaden sensitive filename protection to match the documented wildcard-style behavior for:
  - `.env*`
  - `credentials*`
  - `secret*`
  - `id_rsa*` and related key-name prefixes
- Make recursive filesystem export skip unreadable descendant directories with a warning instead of aborting the entire walk
- Preserve the leading `/` for absolute stdin paths in the project tree so the tree matches absolute file headings
- Pass the tag name into `make` in the release workflow so release binaries report the actual version instead of `dev`
- Extend CLI coverage for:
  - additional sensitive filename variants
  - unreadable descendant directories
  - absolute stdin paths in the tree
  - root-only skipping of the unreadable-file permission test

## Why
These changes bring the implementation in line with the documented behavior, make recursive exports more resilient to partial filesystem access problems, keep the tree view consistent with exported headings, and ensure release artifacts report the correct version.

## Verification
- Ran `make test` successfully
- Release-version wiring to try in CI