### PR TITLE
add hunk-only exports for git diff modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ fuori [OPTIONS]
 | `--from-stdin` | Read paths from stdin |
 | `-0`, `--null` | Use NUL as the stdin delimiter (requires `--from-stdin`) |
 | `--line-numbers` | Prefix exported code lines with line numbers |
+| `--hunks [<n>]` | In Git delta modes, export only changed hunks plus context lines |
 | `--tree` / `--no-tree` | Include/omit project tree (default: on) |
 | `--tree-depth <n>` | Limit tree render depth |
 | `-s <size_kb>` | Max file size in KB (default: 100) |
@@ -109,6 +110,7 @@ fuori [OPTIONS]
 
 Git selection flags (`--staged`, `--unstaged`, `--diff`) and `--from-stdin` are mutually exclusive; `--no-git` cannot be combined with them.
 `--no-default-ignore` only applies to filesystem selection.
+`--hunks` only applies to `--staged`, `--unstaged`, and `--diff`.
 
 **Examples:**
 
@@ -118,6 +120,8 @@ fuori --unstaged                   # Export unstaged changes
 fuori --staged -o review.md        # Staged changes to a named file
 fuori --diff HEAD~3..HEAD          # Files changed in the last 3 commits
 fuori --diff main...HEAD           # Changes since branching from main
+fuori --staged --hunks             # Only changed hunks with default context
+fuori --diff main...HEAD --hunks=8 # Wider hunk context for review
 fuori -o - > codebase.md           # Pipe to stdout
 fuori --no-tree                    # Skip the project tree section
 fuori --tree-depth 2               # Shallow tree
@@ -196,6 +200,9 @@ Additional semantics:
 - `--unstaged` does not include untracked files
 - Renamed files are exported under the current path reported by Git
 - `--staged`, `--unstaged`, and `--diff` include a `Change Context` section with change status summaries
+- `--hunks[=N]` narrows Git delta exports to changed hunks plus `N` lines of surrounding context (`3` by default)
+- Added files still export as full files under `--hunks`
+- Delta entries with no renderable changed-line ranges stay in `Change Context` but omit file bodies and tree entries under `--hunks`
 - If Git selects no files, `fuori` still succeeds and writes an empty export
 
 ## Stdin File Selection
@@ -254,12 +261,12 @@ Sensitive files are skipped by default unless `--allow-sensitive` is set.
 
 The output markdown file will contain:
 
-1. A preamble with repository, mode, and generation timestamp metadata, plus `Line numbers: on` when enabled, and a short mode description
+1. A preamble with repository, mode, and generation timestamp metadata, plus `Line numbers: on` and `Hunks: on (context: N)` when enabled, and a short mode description
 2. A `Change Context` section for `--staged`, `--unstaged`, and `--diff` exports
 3. A project tree section that reflects the exported artifact (enabled by default)
 4. A header with the file path
-5. A code block with the file content
-6. Optional line-number prefixes inside code blocks when `--line-numbers` is set
+5. Either a full-file code block or one or more hunk slices separated by omission markers such as `... 84 unchanged lines omitted ...`
+6. Optional line-number prefixes inside code blocks when `--line-numbers` is set; hunk exports keep original file line numbers
 7. Appropriate language identifiers for syntax highlighting
 8. A `stderr` summary of files, bytes, and estimated tokens after successful completion
 

--- a/src/git_paths.c
+++ b/src/git_paths.c
@@ -16,6 +16,7 @@ typedef enum {
 } GitProbeResult;
 
 #define GIT_SELECTION_ARGS_MAX 13
+#define GIT_HUNK_ARGS_MAX 13
 
 typedef struct {
     char* repo_root;
@@ -33,12 +34,23 @@ static int compare_selected_paths(const void* lhs, const void* rhs) {
     if (open_cmp != 0) {
         return open_cmp;
     }
+    const char* left_repo_rel = left->repo_rel_path ? left->repo_rel_path : "";
+    const char* right_repo_rel = right->repo_rel_path ? right->repo_rel_path : "";
+    int repo_rel_cmp = strcmp(left_repo_rel, right_repo_rel);
+    if (repo_rel_cmp != 0) {
+        return repo_rel_cmp;
+    }
     if (left->change_type != right->change_type) {
         return (left->change_type < right->change_type) ? -1 : 1;
     }
     const char* left_previous = left->previous_display_path ? left->previous_display_path : "";
     const char* right_previous = right->previous_display_path ? right->previous_display_path : "";
-    return strcmp(left_previous, right_previous);
+    int previous_cmp = strcmp(left_previous, right_previous);
+    if (previous_cmp != 0) {
+        return previous_cmp;
+    }
+    return strcmp(left->previous_repo_rel_path ? left->previous_repo_rel_path : "",
+                  right->previous_repo_rel_path ? right->previous_repo_rel_path : "");
 }
 
 void free_selected_paths(SelectedPath* paths, size_t count) {
@@ -46,7 +58,9 @@ void free_selected_paths(SelectedPath* paths, size_t count) {
     for (size_t i = 0; i < count; i++) {
         free(paths[i].open_path);
         free(paths[i].display_path);
+        free(paths[i].repo_rel_path);
         free(paths[i].previous_display_path);
+        free(paths[i].previous_repo_rel_path);
     }
     free(paths);
 }
@@ -67,22 +81,32 @@ static int normalize_selected_paths(SelectedPath* paths, size_t* count) {
         for (size_t i = 1; i < *count; i++) {
             if (strcmp(paths[i - 1].open_path, paths[i].open_path) == 0 &&
                 strcmp(paths[i - 1].display_path, paths[i].display_path) == 0 &&
+                strcmp(paths[i - 1].repo_rel_path ? paths[i - 1].repo_rel_path : "",
+                       paths[i].repo_rel_path ? paths[i].repo_rel_path : "") == 0 &&
                 paths[i - 1].change_type == paths[i].change_type &&
                 strcmp(paths[i - 1].previous_display_path ? paths[i - 1].previous_display_path : "",
-                       paths[i].previous_display_path ? paths[i].previous_display_path : "") == 0) {
+                       paths[i].previous_display_path ? paths[i].previous_display_path : "") == 0 &&
+                strcmp(paths[i - 1].previous_repo_rel_path ? paths[i - 1].previous_repo_rel_path : "",
+                       paths[i].previous_repo_rel_path ? paths[i].previous_repo_rel_path : "") == 0) {
                 free(paths[i].open_path);
                 free(paths[i].display_path);
+                free(paths[i].repo_rel_path);
                 free(paths[i].previous_display_path);
+                free(paths[i].previous_repo_rel_path);
                 paths[i].open_path = NULL;
                 paths[i].display_path = NULL;
+                paths[i].repo_rel_path = NULL;
                 paths[i].previous_display_path = NULL;
+                paths[i].previous_repo_rel_path = NULL;
                 continue;
             }
             if (unique_count != i) {
                 paths[unique_count] = paths[i];
                 paths[i].open_path = NULL;
                 paths[i].display_path = NULL;
+                paths[i].repo_rel_path = NULL;
                 paths[i].previous_display_path = NULL;
+                paths[i].previous_repo_rel_path = NULL;
             }
             unique_count++;
         }
@@ -417,15 +441,41 @@ static int append_selected_path(SelectedPath** paths,
         return -1;
     }
 
+    (*paths)[*count].repo_rel_path = strdup(repo_rel);
+    if (!(*paths)[*count].repo_rel_path) {
+        free((*paths)[*count].open_path);
+        free((*paths)[*count].display_path);
+        (*paths)[*count].open_path = NULL;
+        (*paths)[*count].display_path = NULL;
+        return -1;
+    }
+
     (*paths)[*count].change_type = change_type;
     (*paths)[*count].previous_display_path = NULL;
+    (*paths)[*count].previous_repo_rel_path = NULL;
     if (previous_display_rel) {
         (*paths)[*count].previous_display_path = strdup(previous_display_rel);
         if (!(*paths)[*count].previous_display_path) {
             free((*paths)[*count].open_path);
             free((*paths)[*count].display_path);
+            free((*paths)[*count].repo_rel_path);
             (*paths)[*count].open_path = NULL;
             (*paths)[*count].display_path = NULL;
+            (*paths)[*count].repo_rel_path = NULL;
+            return -1;
+        }
+    }
+    if (previous_repo_rel) {
+        (*paths)[*count].previous_repo_rel_path = strdup(previous_repo_rel);
+        if (!(*paths)[*count].previous_repo_rel_path) {
+            free((*paths)[*count].open_path);
+            free((*paths)[*count].display_path);
+            free((*paths)[*count].repo_rel_path);
+            free((*paths)[*count].previous_display_path);
+            (*paths)[*count].open_path = NULL;
+            (*paths)[*count].display_path = NULL;
+            (*paths)[*count].repo_rel_path = NULL;
+            (*paths)[*count].previous_display_path = NULL;
             return -1;
         }
     }
@@ -464,8 +514,10 @@ static int append_literal_selected_path(SelectedPath** paths,
     }
     memcpy((*paths)[*count].display_path, path, path_len);
     (*paths)[*count].display_path[path_len] = '\0';
+    (*paths)[*count].repo_rel_path = NULL;
     (*paths)[*count].change_type = SELECTED_PATH_CHANGE_NONE;
     (*paths)[*count].previous_display_path = NULL;
+    (*paths)[*count].previous_repo_rel_path = NULL;
 
     (*count)++;
     return 0;
@@ -735,6 +787,263 @@ static int build_git_selection_args(const GitRepoPaths* repo,
     return 0;
 }
 
+static int append_git_hunk_range(GitFileHunks* hunks, size_t* capacity, size_t new_start, size_t new_count) {
+    GitHunkRange* new_ranges;
+    size_t new_capacity;
+
+    if (!hunks || !capacity) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (hunks->count == *capacity) {
+        new_capacity = (*capacity == 0) ? 4 : *capacity * 2;
+        new_ranges = realloc(hunks->ranges, new_capacity * sizeof(*new_ranges));
+        if (!new_ranges) {
+            return -1;
+        }
+        hunks->ranges = new_ranges;
+        *capacity = new_capacity;
+    }
+
+    hunks->ranges[hunks->count].new_start = new_start;
+    hunks->ranges[hunks->count].new_count = new_count;
+    hunks->count++;
+    return 0;
+}
+
+static int parse_hunk_number(const char** cursor, const char* end, size_t* value_out) {
+    size_t value = 0;
+    const char* p;
+
+    if (!cursor || !*cursor || !value_out) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    p = *cursor;
+    if (p >= end || *p < '0' || *p > '9') {
+        errno = EINVAL;
+        return -1;
+    }
+
+    while (p < end && *p >= '0' && *p <= '9') {
+        unsigned digit = (unsigned)(*p - '0');
+        if (value > (SIZE_MAX - digit) / 10) {
+            errno = EOVERFLOW;
+            return -1;
+        }
+        value = value * 10 + digit;
+        p++;
+    }
+
+    *cursor = p;
+    *value_out = value;
+    return 0;
+}
+
+static int parse_unified_hunk_header(const char* line,
+                                     size_t line_len,
+                                     size_t* new_start_out,
+                                     size_t* new_count_out) {
+    const char* p;
+    const char* end;
+    size_t ignored = 0;
+    size_t new_start = 0;
+    size_t new_count = 1;
+
+    if (!line || !new_start_out || !new_count_out) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (line_len < 4 || line[0] != '@' || line[1] != '@') {
+        return 0;
+    }
+
+    p = line + 2;
+    end = line + line_len;
+    while (p < end && *p == ' ') {
+        p++;
+    }
+    if (p >= end || *p != '-') {
+        errno = EINVAL;
+        return -1;
+    }
+    p++;
+    if (parse_hunk_number(&p, end, &ignored) != 0) {
+        return -1;
+    }
+    if (p < end && *p == ',') {
+        p++;
+        if (parse_hunk_number(&p, end, &ignored) != 0) {
+            return -1;
+        }
+    }
+    while (p < end && *p == ' ') {
+        p++;
+    }
+    if (p >= end || *p != '+') {
+        errno = EINVAL;
+        return -1;
+    }
+    p++;
+    if (parse_hunk_number(&p, end, &new_start) != 0) {
+        return -1;
+    }
+    if (p < end && *p == ',') {
+        p++;
+        if (parse_hunk_number(&p, end, &new_count) != 0) {
+            return -1;
+        }
+    }
+    while (p < end && *p == ' ') {
+        p++;
+    }
+    if ((size_t)(end - p) < 2 || p[0] != '@' || p[1] != '@') {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *new_start_out = new_start;
+    *new_count_out = new_count;
+    return 1;
+}
+
+static int parse_hunk_ranges_from_diff_output(const unsigned char* output,
+                                              size_t output_len,
+                                              GitFileHunks* hunks) {
+    size_t start = 0;
+    size_t capacity = 0;
+
+    if (!hunks) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    while (start < output_len) {
+        size_t end = start;
+        size_t new_start = 0;
+        size_t new_count = 0;
+        int header_status;
+
+        while (end < output_len && output[end] != '\n') {
+            end++;
+        }
+        if (end > start && output[end - 1] == '\r') {
+            end--;
+        }
+
+        header_status = parse_unified_hunk_header((const char*)(output + start),
+                                                  end - start,
+                                                  &new_start,
+                                                  &new_count);
+        if (header_status < 0) {
+            return -1;
+        }
+        if (header_status > 0 &&
+            append_git_hunk_range(hunks, &capacity, new_start, new_count) != 0) {
+            return -1;
+        }
+
+        start = (end < output_len && output[end] == '\n') ? end + 1 : output_len;
+    }
+
+    return 0;
+}
+
+static int derive_repo_root_from_selected_paths(const SelectedPath* paths,
+                                                size_t path_count,
+                                                char** repo_root_out) {
+    for (size_t i = 0; i < path_count; i++) {
+        const SelectedPath* path = &paths[i];
+        size_t open_len;
+        size_t repo_rel_len;
+        size_t repo_root_len;
+        char* repo_root;
+
+        if (!path->open_path || !path->repo_rel_path) {
+            continue;
+        }
+
+        open_len = strlen(path->open_path);
+        repo_rel_len = strlen(path->repo_rel_path);
+        if (open_len <= repo_rel_len ||
+            strcmp(path->open_path + open_len - repo_rel_len, path->repo_rel_path) != 0 ||
+            path->open_path[open_len - repo_rel_len - 1] != '/') {
+            errno = EINVAL;
+            return -1;
+        }
+
+        repo_root_len = open_len - repo_rel_len - 1;
+        if (repo_root_len == 0) {
+            repo_root = strdup("/");
+        } else {
+            repo_root = malloc(repo_root_len + 1);
+            if (repo_root) {
+                memcpy(repo_root, path->open_path, repo_root_len);
+                repo_root[repo_root_len] = '\0';
+            }
+        }
+        if (!repo_root) {
+            return -1;
+        }
+
+        *repo_root_out = repo_root;
+        return 0;
+    }
+
+    errno = EINVAL;
+    return -1;
+}
+
+static int build_git_hunk_args(const char* repo_root,
+                               FileSelectionMode mode,
+                               const char* diff_range,
+                               const SelectedPath* path,
+                               const char* repo_rel_path,
+                               const char** args,
+                               size_t args_size) {
+    size_t argc = 0;
+
+    if (!repo_root || !path || !repo_rel_path || !args || args_size < 1) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (append_arg(args, args_size, &argc, "git") != 0 ||
+        append_arg(args, args_size, &argc, "-C") != 0 ||
+        append_arg(args, args_size, &argc, repo_root) != 0 ||
+        append_arg(args, args_size, &argc, "diff") != 0) {
+        return -1;
+    }
+    if (mode == FILE_SELECTION_GIT_STAGED &&
+        append_arg(args, args_size, &argc, "--cached") != 0) {
+        return -1;
+    }
+    if (append_arg(args, args_size, &argc, "-U0") != 0 ||
+        append_arg(args, args_size, &argc, "--no-color") != 0 ||
+        append_arg(args, args_size, &argc, "--no-ext-diff") != 0) {
+        return -1;
+    }
+    if (mode == FILE_SELECTION_GIT_DIFF &&
+        append_arg(args, args_size, &argc, diff_range) != 0) {
+        return -1;
+    }
+    if (append_arg(args, args_size, &argc, "--") != 0) {
+        return -1;
+    }
+    if (path->change_type == SELECTED_PATH_CHANGE_RENAMED &&
+        path->previous_repo_rel_path &&
+        append_arg(args, args_size, &argc, path->previous_repo_rel_path) != 0) {
+        return -1;
+    }
+    if (append_arg(args, args_size, &argc, repo_rel_path) != 0) {
+        return -1;
+    }
+
+    args[argc] = NULL;
+    return 0;
+}
+
 int collect_stdin_paths(int null_delim,
                         SelectedPath** paths_out,
                         size_t* count_out) {
@@ -868,6 +1177,101 @@ cleanup:
     return status;
 }
 
+int collect_git_hunks(FileSelectionMode mode,
+                      const char* diff_range,
+                      const SelectedPath* paths,
+                      size_t path_count,
+                      GitFileHunks** hunks_out,
+                      size_t* hunk_count_out) {
+    char* repo_root = NULL;
+    GitFileHunks* hunks = NULL;
+    int status = -1;
+
+    if (!hunks_out || !hunk_count_out || (path_count > 0 && !paths)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *hunks_out = NULL;
+    *hunk_count_out = 0;
+
+    if (mode != FILE_SELECTION_GIT_STAGED &&
+        mode != FILE_SELECTION_GIT_UNSTAGED &&
+        mode != FILE_SELECTION_GIT_DIFF) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (path_count == 0) {
+        return 0;
+    }
+
+    hunks = calloc(path_count, sizeof(*hunks));
+    if (!hunks) {
+        return -1;
+    }
+
+    if (derive_repo_root_from_selected_paths(paths, path_count, &repo_root) != 0) {
+        goto cleanup;
+    }
+
+    for (size_t i = 0; i < path_count; i++) {
+        const char* args[GIT_HUNK_ARGS_MAX];
+        unsigned char* output = NULL;
+        size_t output_len = 0;
+        int exit_status = 0;
+        int exec_errno = 0;
+
+        if (paths[i].change_type == SELECTED_PATH_CHANGE_ADDED) {
+            continue;
+        }
+        if (!paths[i].repo_rel_path) {
+            errno = EINVAL;
+            goto cleanup;
+        }
+        if (build_git_hunk_args(repo_root,
+                                mode,
+                                diff_range,
+                                &paths[i],
+                                paths[i].repo_rel_path,
+                                args,
+                                GIT_HUNK_ARGS_MAX) != 0) {
+            goto cleanup;
+        }
+        if (run_command_capture(args, 0, &output, &output_len, &exit_status, &exec_errno) != 0) {
+            perror("Error running git");
+            free(output);
+            goto cleanup;
+        }
+        if (exec_errno != 0) {
+            errno = exec_errno;
+            perror("Error executing git");
+            free(output);
+            goto cleanup;
+        }
+        if (!WIFEXITED(exit_status) || WEXITSTATUS(exit_status) != 0) {
+            fprintf(stderr, "git diff failed while collecting hunks for %s\n", paths[i].display_path);
+            free(output);
+            goto cleanup;
+        }
+        if (parse_hunk_ranges_from_diff_output(output, output_len, &hunks[i]) != 0) {
+            free(output);
+            goto cleanup;
+        }
+        free(output);
+    }
+
+    *hunks_out = hunks;
+    *hunk_count_out = path_count;
+    hunks = NULL;
+    status = 0;
+
+cleanup:
+    free(repo_root);
+    free_git_hunks(hunks, path_count);
+    return status;
+}
+
 int resolve_repository_name(FileSelectionMode mode, char* buffer, size_t buffer_size) {
     char cwd[MAX_PATH_LENGTH];
     char* repo_root = NULL;
@@ -897,4 +1301,15 @@ int resolve_repository_name(FileSelectionMode mode, char* buffer, size_t buffer_
 
     free(repo_root);
     return 0;
+}
+
+void free_git_hunks(GitFileHunks* hunks, size_t count) {
+    if (!hunks) {
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        free(hunks[i].ranges);
+    }
+    free(hunks);
 }

--- a/src/git_paths.h
+++ b/src/git_paths.h
@@ -15,9 +15,21 @@ typedef enum {
 typedef struct {
     char* open_path;
     char* display_path;
+    char* repo_rel_path;
     SelectedPathChangeType change_type;
     char* previous_display_path;
+    char* previous_repo_rel_path;
 } SelectedPath;
+
+typedef struct {
+    size_t new_start;
+    size_t new_count;
+} GitHunkRange;
+
+typedef struct {
+    GitHunkRange* ranges;
+    size_t count;
+} GitFileHunks;
 
 typedef enum {
     GIT_PATHS_COLLECTED = 0,
@@ -33,7 +45,14 @@ int collect_git_paths(FileSelectionMode mode,
 int collect_stdin_paths(int null_delim,
                         SelectedPath** paths_out,
                         size_t* count_out);
+int collect_git_hunks(FileSelectionMode mode,
+                      const char* diff_range,
+                      const SelectedPath* paths,
+                      size_t path_count,
+                      GitFileHunks** hunks_out,
+                      size_t* hunk_count_out);
 int resolve_repository_name(FileSelectionMode mode, char* buffer, size_t buffer_size);
+void free_git_hunks(GitFileHunks* hunks, size_t count);
 void free_selected_paths(SelectedPath* paths, size_t count);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -216,7 +216,9 @@ static void compact_selected_paths_to_export_plan(SelectedPath* selected_paths,
                 selected_paths[write_index] = *path;
                 path->open_path = NULL;
                 path->display_path = NULL;
+                path->repo_rel_path = NULL;
                 path->previous_display_path = NULL;
+                path->previous_repo_rel_path = NULL;
             }
             write_index++;
             continue;
@@ -224,10 +226,14 @@ static void compact_selected_paths_to_export_plan(SelectedPath* selected_paths,
 
         free(path->open_path);
         free(path->display_path);
+        free(path->repo_rel_path);
         free(path->previous_display_path);
+        free(path->previous_repo_rel_path);
         path->open_path = NULL;
         path->display_path = NULL;
+        path->repo_rel_path = NULL;
         path->previous_display_path = NULL;
+        path->previous_repo_rel_path = NULL;
     }
 
     *selected_count = write_index;
@@ -318,11 +324,6 @@ int main(int argc, char* argv[]) {
         compact_selected_paths_to_export_plan(selected_paths, &selected_count, &plan);
     }
 
-    if (prepare_render_plan(&plan, &render_info) != 0) {
-        perror("Error preparing render plan");
-        goto cleanup;
-    }
-
     if (resolve_repository_name(options.resolved_mode, repository_name, sizeof(repository_name)) != 0) {
         perror("Error resolving repository name");
         goto cleanup;
@@ -340,8 +341,15 @@ int main(int argc, char* argv[]) {
     render_ctx.selected_count = selected_count;
     render_ctx.diff_range = options.diff_range;
     render_ctx.show_line_numbers = options.show_line_numbers;
+    render_ctx.show_hunks = options.show_hunks;
     render_ctx.show_tree = ctx.show_tree;
+    render_ctx.hunk_context_lines = options.hunk_context_lines;
     render_ctx.tree_depth = ctx.tree_depth;
+
+    if (prepare_render_plan(&plan, &render_ctx, &render_info) != 0) {
+        perror("Error preparing render plan");
+        goto cleanup;
+    }
 
     if (calculate_export_metrics(&plan, &render_info, &render_ctx, &metrics) != 0) {
         perror("Error calculating export metrics");
@@ -426,7 +434,10 @@ int main(int argc, char* argv[]) {
     }
 
     if (render_ctx.show_tree) {
-        if (write_project_tree(output_file, &plan, render_ctx.tree_depth) != 0) {
+        if (write_project_tree_filtered(output_file,
+                                        &plan,
+                                        render_info.include_mask,
+                                        render_ctx.tree_depth) != 0) {
             perror("Error writing project tree");
             goto cleanup;
         }

--- a/src/options.c
+++ b/src/options.c
@@ -32,6 +32,36 @@ static int parse_positive_size_value(const char* value,
     return 0;
 }
 
+static int parse_nonnegative_size_value(const char* value,
+                                        const char* label,
+                                        size_t max_value,
+                                        size_t* out) {
+    char* endptr;
+    unsigned long long parsed;
+
+    if (!value || !out) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (value[0] == '+' || value[0] == '-') {
+        fprintf(stderr, "Invalid %s value: %s\n", label, value);
+        fprintf(stderr, "Use -h or --help for usage information\n");
+        return -1;
+    }
+
+    errno = 0;
+    parsed = strtoull(value, &endptr, 10);
+    if (*value == '\0' || *endptr != '\0' ||
+        errno == ERANGE || parsed > max_value) {
+        fprintf(stderr, "Invalid %s value: %s\n", label, value);
+        fprintf(stderr, "Use -h or --help for usage information\n");
+        return -1;
+    }
+
+    *out = (size_t)parsed;
+    return 0;
+}
+
 static void print_selection_mode_conflict(void) {
     fprintf(stderr, "--from-stdin, --staged, --unstaged, and --diff are mutually exclusive\n");
     fprintf(stderr, "Use -h or --help for usage information\n");
@@ -39,6 +69,11 @@ static void print_selection_mode_conflict(void) {
 
 static void print_no_default_ignore_conflict(void) {
     fprintf(stderr, "--no-default-ignore can only be used with filesystem selection\n");
+    fprintf(stderr, "Use -h or --help for usage information\n");
+}
+
+static void print_hunks_conflict(void) {
+    fprintf(stderr, "--hunks can only be used with --staged, --unstaged, or --diff\n");
     fprintf(stderr, "Use -h or --help for usage information\n");
 }
 
@@ -52,6 +87,7 @@ void init_cli_options(CliOptions* options) {
     options->show_tree = 1;
     options->tree_depth = SIZE_MAX;
     options->warn_tokens = DEFAULT_WARN_TOKENS;
+    options->hunk_context_lines = 3;
     options->output_path = DEFAULT_OUTPUT_FILE;
     options->requested_mode = FILE_SELECTION_AUTO;
     options->resolved_mode = FILE_SELECTION_RECURSIVE;
@@ -73,6 +109,7 @@ void print_usage(const char* argv0) {
     printf("                      --from-stdin, --staged, --unstaged, and --diff are mutually exclusive\n");
     printf("  -0, --null          Use NUL as the input record delimiter instead of newline (requires --from-stdin)\n");
     printf("      --line-numbers  Prefix exported code lines with line numbers\n");
+    printf("      --hunks[=N]     Export only changed hunks with N context lines (default: 3)\n");
     printf("      --tree          Include a directory tree section (default)\n");
     printf("      --no-tree       Omit the directory tree section\n");
     printf("      --tree-depth    Limit tree rendering depth to N levels\n");
@@ -156,6 +193,25 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
             options->show_tree = 0;
         } else if (strcmp(argv[i], "--line-numbers") == 0) {
             options->show_line_numbers = 1;
+        } else if (strcmp(argv[i], "--hunks") == 0) {
+            options->show_hunks = 1;
+            options->hunk_context_lines = 3;
+            if (i + 1 < argc && argv[i + 1][0] != '-') {
+                if (parse_nonnegative_size_value(argv[++i],
+                                                 "hunk context",
+                                                 SIZE_MAX,
+                                                 &options->hunk_context_lines) != 0) {
+                    return -1;
+                }
+            }
+        } else if (strncmp(argv[i], "--hunks=", 8) == 0) {
+            options->show_hunks = 1;
+            if (parse_nonnegative_size_value(argv[i] + 8,
+                                             "hunk context",
+                                             SIZE_MAX,
+                                             &options->hunk_context_lines) != 0) {
+                return -1;
+            }
         } else if (strcmp(argv[i], "--tree-depth") == 0) {
             if (i + 1 < argc) {
                 if (parse_positive_size_value(argv[++i], "tree depth", SIZE_MAX, &options->tree_depth) != 0) {
@@ -265,6 +321,15 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
          options->requested_mode == FILE_SELECTION_GIT_UNSTAGED ||
          options->requested_mode == FILE_SELECTION_GIT_DIFF)) {
         print_no_default_ignore_conflict();
+        return -1;
+    }
+
+    if (options->show_hunks &&
+        (options->requested_mode == FILE_SELECTION_AUTO ||
+         options->requested_mode == FILE_SELECTION_RECURSIVE ||
+         options->requested_mode == FILE_SELECTION_GIT_WORKTREE ||
+         options->requested_mode == FILE_SELECTION_STDIN)) {
+        print_hunks_conflict();
         return -1;
     }
 

--- a/src/options.h
+++ b/src/options.h
@@ -13,9 +13,11 @@ typedef struct {
     int stdin_null_delim;
     int show_tree;
     int show_line_numbers;
+    int show_hunks;
     int no_default_ignore;
     int allow_sensitive;
     size_t max_file_size;
+    size_t hunk_context_lines;
     size_t tree_depth;
     size_t warn_tokens;
     size_t max_tokens;

--- a/src/render.c
+++ b/src/render.c
@@ -50,6 +50,15 @@ typedef struct {
     size_t* total;
 } RenderSink;
 
+typedef struct {
+    size_t* starts;
+    size_t* ends;
+    size_t count;
+} LineIndex;
+
+static int count_fence_bytes(size_t* total, size_t count, const char* lang);
+static int write_fence(FILE* out, size_t count, const char* lang);
+
 static const char* export_description(FileSelectionMode mode) {
     switch (mode) {
         case FILE_SELECTION_GIT_WORKTREE:
@@ -159,6 +168,21 @@ static int sink_write_bytes(RenderSink* sink, const void* data, size_t len) {
     }
     if (sink->total) {
         return add_size(sink->total, len);
+    }
+    errno = EINVAL;
+    return -1;
+}
+
+static int sink_write_fence(RenderSink* sink, size_t count, const char* lang) {
+    if (!sink) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (sink->out) {
+        return write_fence(sink->out, count, lang);
+    }
+    if (sink->total) {
+        return count_fence_bytes(sink->total, count, lang);
     }
     errno = EINVAL;
     return -1;
@@ -298,6 +322,15 @@ static int emit_export_header(RenderSink* sink, const ExportRenderContext* ctx) 
         (sink_write_text(sink, "\nLine numbers: on") != 0)) {
         return -1;
     }
+    if (ctx->show_hunks) {
+        char context_buf[32];
+        if (format_size_value(ctx->hunk_context_lines, context_buf, sizeof(context_buf)) != 0 ||
+            sink_write_text(sink, "\nHunks: on (context: ") != 0 ||
+            sink_write_text(sink, context_buf) != 0 ||
+            sink_write_char(sink, ')') != 0) {
+            return -1;
+        }
+    }
 
     if (sink_write_text(sink, "\n\n") != 0 ||
         sink_write_text(sink, export_description(ctx->mode)) != 0) {
@@ -390,29 +423,442 @@ static size_t compute_fence_length(const ExportEntry* entry) {
     return (max_run >= 3) ? max_run + 1 : 3;
 }
 
-int prepare_render_plan(const ExportPlan* plan, RenderPlanInfo* info) {
-    if (!plan || !info) {
+static int append_render_range(RenderEntryInfo* info,
+                               size_t* capacity,
+                               size_t start_line,
+                               size_t end_line) {
+    RenderLineRange* new_ranges;
+    size_t new_capacity;
+
+    if (!info || !capacity || start_line == 0 || end_line < start_line) {
         errno = EINVAL;
         return -1;
     }
 
-    info->fence_lengths = NULL;
-    info->count = 0;
+    if (info->range_count > 0) {
+        RenderLineRange* last = &info->ranges[info->range_count - 1];
+        if (start_line <= last->end_line + 1) {
+            if (end_line > last->end_line) {
+                last->end_line = end_line;
+            }
+            return 0;
+        }
+    }
 
+    if (info->range_count == *capacity) {
+        new_capacity = (*capacity == 0) ? 4 : *capacity * 2;
+        new_ranges = realloc(info->ranges, new_capacity * sizeof(*new_ranges));
+        if (!new_ranges) {
+            return -1;
+        }
+        info->ranges = new_ranges;
+        *capacity = new_capacity;
+    }
+
+    info->ranges[info->range_count].start_line = start_line;
+    info->ranges[info->range_count].end_line = end_line;
+    info->range_count++;
+    return 0;
+}
+
+static int compute_entry_render_ranges(const ExportEntry* entry,
+                                       const GitFileHunks* hunks,
+                                       size_t context_lines,
+                                       RenderEntryInfo* info) {
+    size_t capacity = 0;
+
+    if (!entry || !hunks || !info) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    info->total_lines = entry_line_count(entry);
+    if (info->total_lines == 0) {
+        return 0;
+    }
+
+    for (size_t i = 0; i < hunks->count; i++) {
+        size_t changed_start = hunks->ranges[i].new_start;
+        size_t changed_end = changed_start;
+        size_t render_start;
+        size_t render_end;
+
+        if (changed_start == 0) {
+            changed_start = 1;
+        }
+        if (changed_start > info->total_lines) {
+            changed_start = info->total_lines;
+        }
+
+        if (hunks->ranges[i].new_count > 0) {
+            if (hunks->ranges[i].new_start > SIZE_MAX - (hunks->ranges[i].new_count - 1)) {
+                changed_end = SIZE_MAX;
+            } else {
+                changed_end = hunks->ranges[i].new_start + hunks->ranges[i].new_count - 1;
+            }
+            if (changed_end < changed_start) {
+                changed_end = changed_start;
+            }
+            if (changed_end > info->total_lines) {
+                changed_end = info->total_lines;
+            }
+        }
+
+        render_start = (changed_start > context_lines) ? changed_start - context_lines : 1;
+        render_end = changed_end;
+        if (context_lines >= info->total_lines ||
+            render_end > info->total_lines - context_lines) {
+            render_end = info->total_lines;
+        } else {
+            render_end += context_lines;
+        }
+
+        if (append_render_range(info, &capacity, render_start, render_end) != 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int build_line_index(const ExportEntry* entry, LineIndex* index) {
+    size_t line_count;
+    size_t line_no = 0;
+    size_t line_start = 0;
+
+    if (!entry || !index) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    memset(index, 0, sizeof(*index));
+    line_count = entry_line_count(entry);
+    if (line_count == 0) {
+        return 0;
+    }
+
+    index->starts = malloc(line_count * sizeof(*index->starts));
+    index->ends = malloc(line_count * sizeof(*index->ends));
+    if (!index->starts || !index->ends) {
+        free(index->starts);
+        free(index->ends);
+        index->starts = NULL;
+        index->ends = NULL;
+        return -1;
+    }
+
+    for (size_t i = 0; i < entry->buf_len; i++) {
+        if (entry->buf[i] != '\n') {
+            continue;
+        }
+        index->starts[line_no] = line_start;
+        index->ends[line_no] = i + 1;
+        line_no++;
+        line_start = i + 1;
+    }
+
+    if (line_start < entry->buf_len || (entry->buf_len > 0 && entry->buf[entry->buf_len - 1] != '\n')) {
+        index->starts[line_no] = line_start;
+        index->ends[line_no] = entry->buf_len;
+        line_no++;
+    }
+
+    index->count = line_no;
+    return 0;
+}
+
+static void free_line_index(LineIndex* index) {
+    if (!index) {
+        return;
+    }
+    free(index->starts);
+    free(index->ends);
+    index->starts = NULL;
+    index->ends = NULL;
+    index->count = 0;
+}
+
+static int emit_entry_heading(RenderSink* sink, const ExportEntry* entry) {
+    if (!sink || !entry) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (sink_write_text(sink, "## ") != 0 ||
+        emit_markdown_path(sink, entry->display_path) != 0 ||
+        sink_write_text(sink, "\n\n") != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int emit_line_range(RenderSink* sink,
+                           const ExportEntry* entry,
+                           const LineIndex* index,
+                           size_t start_line,
+                           size_t end_line,
+                           int show_line_numbers,
+                           size_t line_number_width) {
+    if (!sink || !entry || !index || start_line == 0 || end_line < start_line || end_line > index->count) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    for (size_t line_no = start_line; line_no <= end_line; line_no++) {
+        size_t offset = line_no - 1;
+        size_t start = index->starts[offset];
+        size_t end = index->ends[offset];
+
+        if (show_line_numbers &&
+            (emit_line_number_prefix(sink, line_no, line_number_width) != 0 ||
+             sink_write_text(sink, " | ") != 0)) {
+            return -1;
+        }
+        if (end > start &&
+            sink_write_bytes(sink, entry->buf + start, end - start) != 0) {
+            return -1;
+        }
+        if (end == start || entry->buf[end - 1] != '\n') {
+            if (sink_write_char(sink, '\n') != 0) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int emit_omission_marker(RenderSink* sink, size_t omitted_lines) {
+    char count_buf[32];
+
+    if (!sink || omitted_lines == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (format_size_value(omitted_lines, count_buf, sizeof(count_buf)) != 0 ||
+        sink_write_text(sink, "... ") != 0 ||
+        sink_write_text(sink, count_buf) != 0 ||
+        sink_write_text(sink, " unchanged lines omitted ...\n\n") != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int emit_full_entry(RenderSink* sink,
+                           const ExportEntry* entry,
+                           const RenderEntryInfo* entry_info,
+                           const ExportRenderContext* ctx) {
+    LineIndex index = {0};
+    size_t width = 0;
+    int status = -1;
+
+    if (!sink || !entry || !entry_info || !ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (emit_entry_heading(sink, entry) != 0 ||
+        sink_write_fence(sink, entry_info->fence_length, entry->lang) != 0) {
+        return -1;
+    }
+
+    if (build_line_index(entry, &index) != 0) {
+        goto cleanup;
+    }
+
+    if (ctx->show_line_numbers) {
+        width = decimal_digit_count(entry_info->total_lines);
+    }
+    if (index.count > 0 &&
+        emit_line_range(sink,
+                        entry,
+                        &index,
+                        1,
+                        index.count,
+                        ctx->show_line_numbers,
+                        width) != 0) {
+        goto cleanup;
+    }
+
+    if (sink_write_fence(sink, entry_info->fence_length, NULL) != 0 ||
+        sink_write_text(sink, "\n\n") != 0) {
+        goto cleanup;
+    }
+
+    status = 0;
+
+cleanup:
+    free_line_index(&index);
+    return status;
+}
+
+static int emit_sliced_entry(RenderSink* sink,
+                             const ExportEntry* entry,
+                             const RenderEntryInfo* entry_info,
+                             const ExportRenderContext* ctx) {
+    LineIndex index = {0};
+    size_t width = 0;
+    size_t previous_end = 0;
+    int status = -1;
+
+    if (!sink || !entry || !entry_info || !ctx || entry_info->range_count == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (emit_entry_heading(sink, entry) != 0 ||
+        build_line_index(entry, &index) != 0) {
+        goto cleanup;
+    }
+
+    if (ctx->show_line_numbers) {
+        width = decimal_digit_count(entry_info->total_lines);
+    }
+
+    for (size_t i = 0; i < entry_info->range_count; i++) {
+        const RenderLineRange* range = &entry_info->ranges[i];
+        if (range->start_line > previous_end + 1 &&
+            emit_omission_marker(sink, range->start_line - previous_end - 1) != 0) {
+            goto cleanup;
+        }
+        if (sink_write_fence(sink, entry_info->fence_length, entry->lang) != 0 ||
+            emit_line_range(sink,
+                            entry,
+                            &index,
+                            range->start_line,
+                            range->end_line,
+                            ctx->show_line_numbers,
+                            width) != 0 ||
+            sink_write_fence(sink, entry_info->fence_length, NULL) != 0 ||
+            sink_write_text(sink, "\n\n") != 0) {
+            goto cleanup;
+        }
+        previous_end = range->end_line;
+    }
+
+    if (entry_info->total_lines > previous_end &&
+        emit_omission_marker(sink, entry_info->total_lines - previous_end) != 0) {
+        goto cleanup;
+    }
+
+    status = 0;
+
+cleanup:
+    free_line_index(&index);
+    return status;
+}
+
+static int emit_entry(RenderSink* sink,
+                      const ExportEntry* entry,
+                      const RenderEntryInfo* entry_info,
+                      const ExportRenderContext* ctx) {
+    if (!sink || !entry || !entry_info || !ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    switch (entry_info->mode) {
+        case RENDER_ENTRY_FULL:
+            return emit_full_entry(sink, entry, entry_info, ctx);
+        case RENDER_ENTRY_SLICED:
+            return emit_sliced_entry(sink, entry, entry_info, ctx);
+        case RENDER_ENTRY_OMIT:
+            return 0;
+        default:
+            errno = EINVAL;
+            return -1;
+    }
+}
+
+int prepare_render_plan(const ExportPlan* plan,
+                        const ExportRenderContext* ctx,
+                        RenderPlanInfo* info) {
+    GitFileHunks* hunks = NULL;
+    size_t hunk_count = 0;
+
+    if (!plan || !ctx || !info) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    memset(info, 0, sizeof(*info));
     if (plan->count == 0) {
         return 0;
     }
 
-    info->fence_lengths = malloc(plan->count * sizeof(*info->fence_lengths));
-    if (!info->fence_lengths) {
+    info->entries = calloc(plan->count, sizeof(*info->entries));
+    info->include_mask = calloc(plan->count, sizeof(*info->include_mask));
+    if (!info->entries || !info->include_mask) {
+        free_render_plan_info(info);
         return -1;
     }
 
     info->count = plan->count;
     for (size_t i = 0; i < plan->count; i++) {
-        info->fence_lengths[i] = compute_fence_length(&plan->entries[i]);
+        info->entries[i].fence_length = compute_fence_length(&plan->entries[i]);
+        info->entries[i].total_lines = entry_line_count(&plan->entries[i]);
+        info->entries[i].mode = RENDER_ENTRY_FULL;
+        info->include_mask[i] = 1;
     }
 
+    if (!ctx->show_hunks) {
+        info->visible_count = plan->count;
+        return 0;
+    }
+
+    if (ctx->selected_count != plan->count ||
+        collect_git_hunks(ctx->mode,
+                          ctx->diff_range,
+                          ctx->selected_paths,
+                          ctx->selected_count,
+                          &hunks,
+                          &hunk_count) != 0 ||
+        hunk_count != plan->count) {
+        free_git_hunks(hunks, hunk_count);
+        free_render_plan_info(info);
+        return -1;
+    }
+
+    info->visible_count = 0;
+    for (size_t i = 0; i < plan->count; i++) {
+        RenderEntryInfo* entry_info = &info->entries[i];
+        const SelectedPath* path = &ctx->selected_paths[i];
+
+        if (strcmp(plan->entries[i].open_path, path->open_path) != 0) {
+            free_git_hunks(hunks, hunk_count);
+            free_render_plan_info(info);
+            errno = EINVAL;
+            return -1;
+        }
+
+        if (path->change_type == SELECTED_PATH_CHANGE_ADDED) {
+            entry_info->mode = RENDER_ENTRY_FULL;
+            info->include_mask[i] = 1;
+            info->visible_count++;
+            continue;
+        }
+
+        if (compute_entry_render_ranges(&plan->entries[i],
+                                        &hunks[i],
+                                        ctx->hunk_context_lines,
+                                        entry_info) != 0) {
+            free_git_hunks(hunks, hunk_count);
+            free_render_plan_info(info);
+            return -1;
+        }
+
+        if (entry_info->range_count > 0) {
+            entry_info->mode = RENDER_ENTRY_SLICED;
+            info->include_mask[i] = 1;
+            info->visible_count++;
+        } else {
+            entry_info->mode = RENDER_ENTRY_OMIT;
+            info->include_mask[i] = 0;
+        }
+    }
+
+    free_git_hunks(hunks, hunk_count);
     return 0;
 }
 
@@ -421,97 +867,17 @@ void free_render_plan_info(RenderPlanInfo* info) {
         return;
     }
 
-    free(info->fence_lengths);
-    info->fence_lengths = NULL;
+    if (info->entries) {
+        for (size_t i = 0; i < info->count; i++) {
+            free(info->entries[i].ranges);
+        }
+    }
+    free(info->entries);
+    free(info->include_mask);
+    info->entries = NULL;
+    info->include_mask = NULL;
     info->count = 0;
-}
-
-static int get_fence_length(const RenderPlanInfo* info, size_t index, size_t* fence_out) {
-    if (!info || !fence_out || index >= info->count) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    *fence_out = info->fence_lengths[index];
-    return 0;
-}
-
-static int emit_entry_body(RenderSink* sink, const ExportEntry* entry, int show_line_numbers) {
-    size_t line_count = 0;
-    size_t width = 0;
-    size_t line_no = 1;
-    size_t line_start = 0;
-
-    if (!sink || !entry) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    if (!show_line_numbers) {
-        if (entry->buf_len > 0 && sink_write_bytes(sink, entry->buf, entry->buf_len) != 0) {
-            return -1;
-        }
-        if (entry->buf_len > 0 &&
-            entry->buf[entry->buf_len - 1] != '\n' &&
-            sink_write_char(sink, '\n') != 0) {
-            return -1;
-        }
-        return 0;
-    }
-
-    line_count = entry_line_count(entry);
-    if (line_count == 0) {
-        return 0;
-    }
-    width = decimal_digit_count(line_count);
-
-    for (size_t i = 0; i < entry->buf_len; i++) {
-        if (entry->buf[i] != '\n') {
-            continue;
-        }
-        if (emit_line_number_prefix(sink, line_no, width) != 0 ||
-            sink_write_text(sink, " | ") != 0 ||
-            sink_write_bytes(sink, entry->buf + line_start, (i - line_start) + 1) != 0) {
-            return -1;
-        }
-        line_no++;
-        line_start = i + 1;
-    }
-
-    if (line_start < entry->buf_len) {
-        if (emit_line_number_prefix(sink, line_no, width) != 0 ||
-            sink_write_text(sink, " | ") != 0 ||
-            sink_write_bytes(sink, entry->buf + line_start, entry->buf_len - line_start) != 0 ||
-            sink_write_char(sink, '\n') != 0) {
-            return -1;
-        }
-    }
-
-    return 0;
-}
-
-static int emit_entry(RenderSink* sink,
-                      const ExportEntry* entry,
-                      size_t fence,
-                      const ExportRenderContext* ctx) {
-    if (!sink || !entry || !ctx) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    if (sink_write_text(sink, "## ") != 0 ||
-        emit_markdown_path(sink, entry->display_path) != 0 ||
-        sink_write_text(sink, "\n\n") != 0 ||
-        (sink->out ? write_fence(sink->out, fence, entry->lang)
-                   : count_fence_bytes(sink->total, fence, entry->lang)) != 0 ||
-        emit_entry_body(sink, entry, ctx->show_line_numbers) != 0 ||
-        (sink->out ? write_fence(sink->out, fence, NULL)
-                   : count_fence_bytes(sink->total, fence, NULL)) != 0 ||
-        sink_write_text(sink, "\n\n") != 0) {
-        return -1;
-    }
-
-    return 0;
+    info->visible_count = 0;
 }
 
 int calculate_export_metrics(const ExportPlan* plan,
@@ -526,26 +892,26 @@ int calculate_export_metrics(const ExportPlan* plan,
         return -1;
     }
 
-    if (emit_export_header(&sink, ctx) != 0) {
-        return -1;
-    }
-    if (emit_change_context(&sink, ctx) != 0) {
+    if (emit_export_header(&sink, ctx) != 0 ||
+        emit_change_context(&sink, ctx) != 0) {
         return -1;
     }
 
-    if (ctx->show_tree && count_project_tree_bytes(plan, ctx->tree_depth, &total) != 0) {
+    if (ctx->show_tree &&
+        count_project_tree_bytes_filtered(plan, info->include_mask, ctx->tree_depth, &total) != 0) {
         return -1;
     }
 
     for (size_t i = 0; i < plan->count; i++) {
-        size_t fence = 0;
-        if (get_fence_length(info, i, &fence) != 0 ||
-            emit_entry(&sink, &plan->entries[i], fence, ctx) != 0) {
+        if (!info->include_mask[i]) {
+            continue;
+        }
+        if (emit_entry(&sink, &plan->entries[i], &info->entries[i], ctx) != 0) {
             return -1;
         }
     }
 
-    metrics->files_exported = plan->count;
+    metrics->files_exported = info->visible_count;
     metrics->bytes_written = total;
     metrics->estimated_tokens = estimate_tokens(total);
     return 0;
@@ -564,7 +930,9 @@ int render_export_plan(FILE* out,
     }
 
     for (size_t i = 0; i < plan->count; i++) {
-        size_t fence = 0;
+        if (!info->include_mask[i]) {
+            continue;
+        }
         if (verbose) {
             fprintf(stderr, "Processing file: %s\n", plan->entries[i].display_path);
         }
@@ -573,8 +941,7 @@ int render_export_plan(FILE* out,
             return -1;
         }
 #endif
-        if (get_fence_length(info, i, &fence) != 0 ||
-            emit_entry(&sink, &plan->entries[i], fence, ctx) != 0) {
+        if (emit_entry(&sink, &plan->entries[i], &info->entries[i], ctx) != 0) {
             return -1;
         }
     }

--- a/src/render.h
+++ b/src/render.h
@@ -13,9 +13,30 @@ typedef struct {
     size_t estimated_tokens;
 } ExportMetrics;
 
+typedef enum {
+    RENDER_ENTRY_FULL = 0,
+    RENDER_ENTRY_SLICED,
+    RENDER_ENTRY_OMIT
+} RenderEntryMode;
+
 typedef struct {
-    size_t* fence_lengths;
+    size_t start_line;
+    size_t end_line;
+} RenderLineRange;
+
+typedef struct {
+    RenderEntryMode mode;
+    size_t fence_length;
+    size_t total_lines;
+    RenderLineRange* ranges;
+    size_t range_count;
+} RenderEntryInfo;
+
+typedef struct {
+    RenderEntryInfo* entries;
+    unsigned char* include_mask;
     size_t count;
+    size_t visible_count;
 } RenderPlanInfo;
 
 typedef struct {
@@ -26,11 +47,15 @@ typedef struct {
     size_t selected_count;
     const char* diff_range;
     int show_line_numbers;
+    int show_hunks;
     int show_tree;
+    size_t hunk_context_lines;
     size_t tree_depth;
 } ExportRenderContext;
 
-int prepare_render_plan(const ExportPlan* plan, RenderPlanInfo* info);
+int prepare_render_plan(const ExportPlan* plan,
+                        const ExportRenderContext* ctx,
+                        RenderPlanInfo* info);
 void free_render_plan_info(RenderPlanInfo* info);
 int calculate_export_metrics(const ExportPlan* plan,
                              const RenderPlanInfo* info,

--- a/src/tree.c
+++ b/src/tree.c
@@ -402,7 +402,10 @@ static int count_tree_children_bytes(const TreeNode* node,
     return 0;
 }
 
-int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
+int write_project_tree_filtered(FILE* out,
+                                const ExportPlan* plan,
+                                const unsigned char* include_mask,
+                                size_t max_depth) {
     TreeNode* root = tree_node_create("", 1);
     TreePrefixBuffer prefix = {0};
     size_t fence_len = 3;
@@ -412,6 +415,9 @@ int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
     }
 
     for (size_t i = 0; i < plan->count; i++) {
+        if (include_mask && !include_mask[i]) {
+            continue;
+        }
         if (tree_add_path(root, plan->entries[i].display_path) != 0) {
             free_tree(root);
             return -1;
@@ -448,7 +454,10 @@ cleanup:
     return result;
 }
 
-int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total) {
+int count_project_tree_bytes_filtered(const ExportPlan* plan,
+                                      const unsigned char* include_mask,
+                                      size_t max_depth,
+                                      size_t* total) {
     TreeNode* root = tree_node_create("", 1);
     size_t fence_len = 3;
     if (!root) {
@@ -456,6 +465,9 @@ int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* t
     }
 
     for (size_t i = 0; i < plan->count; i++) {
+        if (include_mask && !include_mask[i]) {
+            continue;
+        }
         if (tree_add_path(root, plan->entries[i].display_path) != 0) {
             free_tree(root);
             return -1;
@@ -482,4 +494,12 @@ int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* t
 
     free_tree(root);
     return count_tree_close_fence_bytes(total, fence_len);
+}
+
+int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth) {
+    return write_project_tree_filtered(out, plan, NULL, max_depth);
+}
+
+int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total) {
+    return count_project_tree_bytes_filtered(plan, NULL, max_depth, total);
 }

--- a/src/tree.h
+++ b/src/tree.h
@@ -8,5 +8,13 @@
 
 int write_project_tree(FILE* out, const ExportPlan* plan, size_t max_depth);
 int count_project_tree_bytes(const ExportPlan* plan, size_t max_depth, size_t* total);
+int write_project_tree_filtered(FILE* out,
+                                const ExportPlan* plan,
+                                const unsigned char* include_mask,
+                                size_t max_depth);
+int count_project_tree_bytes_filtered(const ExportPlan* plan,
+                                      const unsigned char* include_mask,
+                                      size_t max_depth,
+                                      size_t* total);
 
 #endif

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -66,6 +66,7 @@ trap 'rm -rf "$TMPDIR"' EXIT INT TERM
 
 (cd "$BIN_DIR" && "$BIN" --help >"$TMPDIR/help_stdout.txt" 2>"$TMPDIR/help_stderr.txt")
 assert_contains "$TMPDIR/help_stdout.txt" "--allow-sensitive"
+assert_contains "$TMPDIR/help_stdout.txt" "--hunks"
 assert_contains "$TMPDIR/help_stdout.txt" "--line-numbers"
 assert_contains "$TMPDIR/help_stdout.txt" "--no-default-ignore"
 assert_file_equals "$TMPDIR/help_stderr.txt" ""
@@ -418,6 +419,11 @@ if printf 'alpha.c\n' | (cd "$STDIN_DIR" && "$BIN" --from-stdin --no-default-ign
 fi
 assert_contains "$STDIN_DIR/stdin_conflict_no_default_ignore.txt" "--no-default-ignore can only be used with filesystem selection"
 
+if printf 'alpha.c\n' | (cd "$STDIN_DIR" && "$BIN" --from-stdin --hunks >/dev/null 2>stdin_conflict_hunks.txt); then
+    fail "expected --from-stdin --hunks to fail"
+fi
+assert_contains "$STDIN_DIR/stdin_conflict_hunks.txt" "--hunks can only be used with --staged, --unstaged, or --diff"
+
 if (cd "$STDIN_DIR" && "$BIN" -0 >/dev/null 2>stdin_null_without_mode_stderr.txt); then
     fail "expected -0 without --from-stdin to fail"
 fi
@@ -517,6 +523,21 @@ if (cd "$REPO" && "$BIN" --staged --no-default-ignore >/dev/null 2>stderr_no_def
 fi
 assert_contains "$REPO/stderr_no_default_ignore_invalid.txt" "--no-default-ignore can only be used with filesystem selection"
 
+if (cd "$REPO" && "$BIN" --hunks >/dev/null 2>stderr_hunks_default_invalid.txt); then
+    fail "expected bare --hunks to fail"
+fi
+assert_contains "$REPO/stderr_hunks_default_invalid.txt" "--hunks can only be used with --staged, --unstaged, or --diff"
+
+if (cd "$REPO" && "$BIN" --no-git --hunks >/dev/null 2>stderr_hunks_no_git_invalid.txt); then
+    fail "expected --no-git --hunks to fail"
+fi
+assert_contains "$REPO/stderr_hunks_no_git_invalid.txt" "--hunks can only be used with --staged, --unstaged, or --diff"
+
+if (cd "$REPO" && "$BIN" --staged --hunks=-1 >/dev/null 2>stderr_hunks_negative_invalid.txt); then
+    fail "expected --staged --hunks=-1 to fail"
+fi
+assert_contains "$REPO/stderr_hunks_negative_invalid.txt" "Invalid hunk context value: -1"
+
 STAGED_REPO="$TMPDIR/staged_repo"
 mkdir -p "$STAGED_REPO"
 (cd "$STAGED_REPO" && git init -q)
@@ -562,6 +583,107 @@ assert_contains "$STAGED_REPO/unstaged_stdout.txt" "Files changed: 1"
 assert_contains "$STAGED_REPO/unstaged_stdout.txt" "- M beta.c"
 assert_contains "$STAGED_REPO/unstaged_stdout.txt" "## beta.c"
 assert_not_contains "$STAGED_REPO/unstaged_stdout.txt" "- A added.c"
+
+HUNKS_REPO="$TMPDIR/hunks_repo"
+mkdir -p "$HUNKS_REPO/sub"
+(cd "$HUNKS_REPO" && git init -q)
+awk 'BEGIN { for (i = 1; i <= 20; i++) printf "int line%d(void) { return %d; }\n", i, i; }' >"$HUNKS_REPO/review.c"
+cat >"$HUNKS_REPO/rename_only.c" <<'EOF_HUNKS_RENAME_ONLY'
+int rename_only(void) { return 1; }
+EOF_HUNKS_RENAME_ONLY
+cat >"$HUNKS_REPO/mode_only.sh" <<'EOF_HUNKS_MODE_ONLY'
+echo one
+echo two
+EOF_HUNKS_MODE_ONLY
+cat >"$HUNKS_REPO/delete_context.c" <<'EOF_HUNKS_DELETE_BASE'
+one
+two
+three
+four
+five
+EOF_HUNKS_DELETE_BASE
+cat >"$HUNKS_REPO/small.c" <<'EOF_HUNKS_SMALL_BASE'
+int small_one(void) { return 1; }
+int small_two(void) { return 2; }
+int small_three(void) { return 3; }
+EOF_HUNKS_SMALL_BASE
+cat >"$HUNKS_REPO/sub/nested.c" <<'EOF_HUNKS_NESTED_BASE'
+int nested_one(void) { return 1; }
+int nested_two(void) { return 2; }
+int nested_three(void) { return 3; }
+int nested_four(void) { return 4; }
+EOF_HUNKS_NESTED_BASE
+(cd "$HUNKS_REPO" && git add review.c rename_only.c mode_only.sh delete_context.c small.c sub/nested.c && \
+    git -c user.name='fuori tests' -c user.email='fuori@example.com' commit -qm base)
+awk 'BEGIN { for (i = 1; i <= 20; i++) { if (i == 2) v = 20; else if (i == 18) v = 180; else v = i; printf "int line%d(void) { return %d; }\n", i, v; } }' >"$HUNKS_REPO/review.c"
+(cd "$HUNKS_REPO" && git add review.c)
+(cd "$HUNKS_REPO" && git mv rename_only.c renamed_only.c)
+chmod +x "$HUNKS_REPO/mode_only.sh"
+(cd "$HUNKS_REPO" && git add mode_only.sh)
+cat >"$HUNKS_REPO/delete_context.c" <<'EOF_HUNKS_DELETE_MOD'
+one
+two
+four
+five
+EOF_HUNKS_DELETE_MOD
+(cd "$HUNKS_REPO" && git add delete_context.c)
+cat >"$HUNKS_REPO/small.c" <<'EOF_HUNKS_SMALL_MOD'
+int small_one(void) { return 1; }
+int small_two(void) { return 20; }
+int small_three(void) { return 3; }
+EOF_HUNKS_SMALL_MOD
+(cd "$HUNKS_REPO" && git add small.c)
+cat >"$HUNKS_REPO/added.c" <<'EOF_HUNKS_ADDED'
+int added(void) { return 99; }
+EOF_HUNKS_ADDED
+(cd "$HUNKS_REPO" && git add added.c)
+cat >"$HUNKS_REPO/sub/nested.c" <<'EOF_HUNKS_NESTED_MOD'
+int nested_one(void) { return 1; }
+int nested_two(void) { return 20; }
+int nested_three(void) { return 3; }
+int nested_four(void) { return 4; }
+EOF_HUNKS_NESTED_MOD
+(cd "$HUNKS_REPO" && git add sub/nested.c)
+
+(cd "$HUNKS_REPO" && "$BIN" --staged --hunks=0 --line-numbers --no-tree -o - >hunks_zero_stdout.txt 2>hunks_zero_stderr.txt)
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "Line numbers: on"
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "Hunks: on (context: 0)"
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "## review.c"
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "2 | int line2(void) { return 20; }"
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "18 | int line18(void) { return 180; }"
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "... 15 unchanged lines omitted ..."
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "- R rename_only.c -> renamed_only.c"
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "- M mode_only.sh"
+assert_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "## added.c"
+assert_not_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "## renamed_only.c"
+assert_not_contains "$HUNKS_REPO/hunks_zero_stdout.txt" "## mode_only.sh"
+
+(cd "$HUNKS_REPO" && "$BIN" --staged --hunks=1 --no-tree -o - >hunks_context_stdout.txt 2>hunks_context_stderr.txt)
+awk '/^## delete_context.c$/{flag=1; next} /^## /{flag=0} flag { print }' "$HUNKS_REPO/hunks_context_stdout.txt" >"$HUNKS_REPO/delete_context_section.txt"
+assert_contains "$HUNKS_REPO/delete_context_section.txt" "one"
+assert_contains "$HUNKS_REPO/delete_context_section.txt" "two"
+assert_contains "$HUNKS_REPO/delete_context_section.txt" "four"
+assert_not_contains "$HUNKS_REPO/delete_context_section.txt" "three"
+
+(cd "$HUNKS_REPO" && "$BIN" --staged --hunks=10 --no-tree -o - >hunks_wide_stdout.txt 2>hunks_wide_stderr.txt)
+awk '/^## small.c$/{flag=1; next} /^## /{flag=0} flag { print }' "$HUNKS_REPO/hunks_wide_stdout.txt" >"$HUNKS_REPO/small_section.txt"
+assert_contains "$HUNKS_REPO/small_section.txt" "int small_one(void) { return 1; }"
+assert_contains "$HUNKS_REPO/small_section.txt" "int small_two(void) { return 20; }"
+assert_contains "$HUNKS_REPO/small_section.txt" "int small_three(void) { return 3; }"
+assert_not_contains "$HUNKS_REPO/small_section.txt" "unchanged lines omitted"
+
+(cd "$HUNKS_REPO" && "$BIN" --staged --hunks -o - >hunks_tree_stdout.txt 2>hunks_tree_stderr.txt)
+assert_contains "$HUNKS_REPO/hunks_tree_stdout.txt" "## Project Tree"
+assert_contains "$HUNKS_REPO/hunks_tree_stdout.txt" "├── added.c"
+assert_contains "$HUNKS_REPO/hunks_tree_stdout.txt" "├── delete_context.c"
+assert_contains "$HUNKS_REPO/hunks_tree_stdout.txt" "├── review.c"
+assert_not_contains "$HUNKS_REPO/hunks_tree_stdout.txt" "└── renamed_only.c"
+assert_not_contains "$HUNKS_REPO/hunks_tree_stdout.txt" "└── mode_only.sh"
+
+(cd "$HUNKS_REPO/sub" && "$BIN" --staged --hunks --no-tree -o - >nested_hunks_stdout.txt 2>nested_hunks_stderr.txt)
+assert_contains "$HUNKS_REPO/sub/nested_hunks_stdout.txt" "## nested.c"
+assert_contains "$HUNKS_REPO/sub/nested_hunks_stdout.txt" "nested_two"
+assert_not_contains "$HUNKS_REPO/sub/nested_hunks_stdout.txt" "## review.c"
 
 SENSITIVE_STAGED_REPO="$TMPDIR/sensitive_staged_repo"
 mkdir -p "$SENSITIVE_STAGED_REPO"


### PR DESCRIPTION
## Summary
Add `--hunks[=N]` for `--staged`, `--unstaged`, and `--diff` so review-oriented exports can include only changed hunks plus configurable surrounding context.

## Changes
- Add `--hunks`, `--hunks=N`, and `--hunks N`
- Reject `--hunks` outside explicit Git delta modes
- Add header metadata for hunk exports:
  - `Hunks: on (context: N)`
- Extend Git-selected path metadata with repo-relative current and previous paths for correct per-file hunk lookup
- Collect per-file unified hunk ranges from Git using path-scoped `git diff -U0`
- Keep added files as full-file exports under `--hunks`
- Treat zero-hunk delta entries as metadata-only:
  - keep them in `Change Context`
  - omit their file body
  - omit them from the project tree
- Add slice-aware render prep with renderer-owned visibility state
- Render omission markers between visible slices:
  - `... X unchanged lines omitted ...`
- Preserve original file line numbers when `--line-numbers` is combined with `--hunks`
- Make tree rendering and byte/token metrics honor only render-visible entries
- Reject signed hunk context values such as `--hunks=-1`
- Update README docs and examples for hunk-mode behavior

## Why
Git delta modes were already useful for narrowing scope, but they still exported full files. `--hunks` makes review exports substantially more precise without changing `fuori`’s model: a single Markdown artifact, grounded in Git, with exact metrics based on the final rendered output.

## Verification
- Ran `make test` successfully
- Manual vetting of some output samples