### PR TITLE
refactor render prep, numeric parsing, and sensitive screening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Wall -Wextra -Wshadow -Wcast-align -Wwrite-strings -Wredundant-decls \
          -Wstrict-prototypes -Wold-style-definition -std=c99 -O2 -D_POSIX_C_SOURCE=200809L
 TARGET = fuori
 TEST_CLI_TARGET = fuori-test
-SOURCES = src/main.c src/collect.c src/render.c src/git_paths.c src/ignore.c src/options.c src/tree.c
+SOURCES = src/main.c src/collect.c src/render.c src/git_paths.c src/ignore.c src/options.c src/tree.c src/sensitive.c
 TEST_TARGET = test_ignore
 TREE_TEST_TARGET = test_tree
 PREFIX ?= /usr/local

--- a/src/collect.c
+++ b/src/collect.c
@@ -1,7 +1,6 @@
 #include "collect.h"
 
 #include <dirent.h>
-#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <fnmatch.h>
@@ -13,6 +12,7 @@
 #include <unistd.h>
 
 #include "ignore.h"
+#include "sensitive.h"
 
 typedef struct {
     const char* const extension;
@@ -166,188 +166,6 @@ static int is_binary_file(const unsigned char* buffer, size_t bytes_read) {
         }
     }
     return (ctrl * 100 / bytes_read) > 2;
-}
-
-static int equals_ignore_case_char(unsigned char lhs, unsigned char rhs) {
-    return tolower(lhs) == tolower(rhs);
-}
-
-static int starts_with_ignore_case(const char* text, const char* prefix) {
-    if (!text || !prefix) return 0;
-    while (*prefix != '\0') {
-        if (*text == '\0' || !equals_ignore_case_char((unsigned char)*text, (unsigned char)*prefix)) {
-            return 0;
-        }
-        text++;
-        prefix++;
-    }
-    return 1;
-}
-
-static int equals_ignore_case(const char* lhs, const char* rhs) {
-    if (!lhs || !rhs) return 0;
-    while (*lhs != '\0' && *rhs != '\0') {
-        if (!equals_ignore_case_char((unsigned char)*lhs, (unsigned char)*rhs)) {
-            return 0;
-        }
-        lhs++;
-        rhs++;
-    }
-    return *lhs == '\0' && *rhs == '\0';
-}
-
-static int ends_with_ignore_case(const char* text, const char* suffix) {
-    size_t text_len;
-    size_t suffix_len;
-
-    if (!text || !suffix) return 0;
-    text_len = strlen(text);
-    suffix_len = strlen(suffix);
-    if (suffix_len > text_len) return 0;
-    return equals_ignore_case(text + text_len - suffix_len, suffix);
-}
-
-static int is_sensitive_basename_prefix(const char* basename, const char* prefix) {
-    if (!basename || !prefix) return 0;
-    return starts_with_ignore_case(basename, prefix);
-}
-
-static int is_sensitive_filename(const char* filepath) {
-    const char* basename = filepath;
-    const char* slash = strrchr(filepath, '/');
-
-    if (!filepath) {
-        return 0;
-    }
-    if (slash) {
-        basename = slash + 1;
-    }
-
-    if (is_sensitive_basename_prefix(basename, ".env") ||
-        is_sensitive_basename_prefix(basename, "credential") ||
-        is_sensitive_basename_prefix(basename, "credentials") ||
-        is_sensitive_basename_prefix(basename, "secret") ||
-        is_sensitive_basename_prefix(basename, "secrets") ||
-        is_sensitive_basename_prefix(basename, "id_rsa") ||
-        is_sensitive_basename_prefix(basename, "id_dsa") ||
-        is_sensitive_basename_prefix(basename, "id_ecdsa") ||
-        is_sensitive_basename_prefix(basename, "id_ed25519") ||
-        ends_with_ignore_case(basename, ".pem") ||
-        ends_with_ignore_case(basename, ".key")) {
-        return 1;
-    }
-
-    return 0;
-}
-
-static int buffer_contains_literal(const unsigned char* buffer,
-                                   size_t bytes_read,
-                                   const char* needle) {
-    size_t needle_len;
-
-    if (!buffer || !needle) {
-        return 0;
-    }
-    needle_len = strlen(needle);
-    if (needle_len == 0 || needle_len > bytes_read) {
-        return 0;
-    }
-
-    for (size_t i = 0; i + needle_len <= bytes_read; i++) {
-        if (memcmp(buffer + i, needle, needle_len) == 0) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-static int is_upper_alnum(unsigned char c) {
-    return (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
-}
-
-static int is_openai_key_char(unsigned char c) {
-    return (c >= 'A' && c <= 'Z') ||
-           (c >= 'a' && c <= 'z') ||
-           (c >= '0' && c <= '9') ||
-           c == '-' ||
-           c == '_';
-}
-
-static int buffer_contains_prefixed_run(const unsigned char* buffer,
-                                        size_t bytes_read,
-                                        const char* prefix,
-                                        size_t required_run_len,
-                                        int (*char_ok)(unsigned char)) {
-    size_t prefix_len;
-
-    if (!buffer || !prefix || !char_ok) {
-        return 0;
-    }
-    prefix_len = strlen(prefix);
-    if (prefix_len == 0 || prefix_len + required_run_len > bytes_read) {
-        return 0;
-    }
-
-    for (size_t i = 0; i + prefix_len + required_run_len <= bytes_read; i++) {
-        if (memcmp(buffer + i, prefix, prefix_len) != 0) {
-            continue;
-        }
-        size_t run_len = 0;
-        while (i + prefix_len + run_len < bytes_read &&
-               char_ok(buffer[i + prefix_len + run_len])) {
-            run_len++;
-        }
-        if (run_len >= required_run_len) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-static int contains_sensitive_content(const unsigned char* buffer, size_t bytes_read) {
-    static const char* private_key_markers[] = {
-        "-----BEGIN PRIVATE KEY-----",
-        "-----BEGIN RSA PRIVATE KEY-----",
-        "-----BEGIN OPENSSH PRIVATE KEY-----",
-        "-----BEGIN EC PRIVATE KEY-----",
-        "-----BEGIN DSA PRIVATE KEY-----",
-        "-----BEGIN PGP PRIVATE KEY BLOCK-----",
-        NULL
-    };
-    static const char* github_prefixes[] = {
-        "ghp_",
-        "gho_",
-        "ghu_",
-        "ghs_",
-        "ghr_",
-        NULL
-    };
-
-    if (!buffer) {
-        return 0;
-    }
-
-    for (size_t i = 0; private_key_markers[i] != NULL; i++) {
-        if (buffer_contains_literal(buffer, bytes_read, private_key_markers[i])) {
-            return 1;
-        }
-    }
-    if (buffer_contains_prefixed_run(buffer, bytes_read, "AKIA", 16, is_upper_alnum) ||
-        buffer_contains_prefixed_run(buffer, bytes_read, "ASIA", 16, is_upper_alnum)) {
-        return 1;
-    }
-    for (size_t i = 0; github_prefixes[i] != NULL; i++) {
-        if (buffer_contains_prefixed_run(buffer, bytes_read, github_prefixes[i], 20, is_openai_key_char)) {
-            return 1;
-        }
-    }
-    if (buffer_contains_prefixed_run(buffer, bytes_read, "sk-", 20, is_openai_key_char)) {
-        return 1;
-    }
-
-    return 0;
 }
 
 static const char* classify_shebang_interpreter(const char* name) {
@@ -692,7 +510,7 @@ static int collect_exportable_file(const char* open_path,
         return 0;
     }
 
-    if (!ctx->allow_sensitive && is_sensitive_filename(open_path)) {
+    if (!ctx->allow_sensitive && fuori_is_sensitive_filename(open_path)) {
         ctx->skipped_sensitive++;
         fprintf(stderr, "Warning: Skipping sensitive file %s\n", display_path);
         return 0;
@@ -727,7 +545,7 @@ static int collect_exportable_file(const char* open_path,
         free(buffer);
         return 0;
     }
-    if (!ctx->allow_sensitive && contains_sensitive_content(buffer, bytes_read)) {
+    if (!ctx->allow_sensitive && fuori_contains_sensitive_content(buffer, bytes_read)) {
         ctx->skipped_sensitive++;
         fprintf(stderr, "Warning: Skipping sensitive file %s\n", display_path);
         free(buffer);

--- a/src/options.c
+++ b/src/options.c
@@ -7,35 +7,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-static int parse_positive_size_value(const char* value,
-                                     const char* label,
-                                     size_t max_value,
-                                     size_t* out) {
-    char* endptr;
-    unsigned long long parsed;
-
-    if (!value || !out) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    errno = 0;
-    parsed = strtoull(value, &endptr, 10);
-    if (*value == '\0' || *endptr != '\0' || parsed == 0 ||
-        errno == ERANGE || parsed > max_value) {
-        fprintf(stderr, "Invalid %s value: %s\n", label, value);
-        fprintf(stderr, "Use -h or --help for usage information\n");
-        return -1;
-    }
-
-    *out = (size_t)parsed;
-    return 0;
-}
-
-static int parse_nonnegative_size_value(const char* value,
-                                        const char* label,
-                                        size_t max_value,
-                                        size_t* out) {
+static int parse_size_value(const char* value,
+                            const char* label,
+                            size_t min_value,
+                            size_t max_value,
+                            size_t* out) {
     char* endptr;
     unsigned long long parsed;
 
@@ -51,7 +27,7 @@ static int parse_nonnegative_size_value(const char* value,
 
     errno = 0;
     parsed = strtoull(value, &endptr, 10);
-    if (*value == '\0' || *endptr != '\0' ||
+    if (*value == '\0' || *endptr != '\0' || parsed < min_value ||
         errno == ERANGE || parsed > max_value) {
         fprintf(stderr, "Invalid %s value: %s\n", label, value);
         fprintf(stderr, "Use -h or --help for usage information\n");
@@ -142,7 +118,7 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
         } else if (strcmp(argv[i], "-s") == 0) {
             if (i + 1 < argc) {
                 size_t size_kb;
-                if (parse_positive_size_value(argv[++i], "size", SIZE_MAX / 1024ULL, &size_kb) != 0) {
+                if (parse_size_value(argv[++i], "size", 1, SIZE_MAX / 1024ULL, &size_kb) != 0) {
                     return -1;
                 }
                 options->max_file_size = size_kb * 1024ULL;
@@ -197,24 +173,26 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
             options->show_hunks = 1;
             options->hunk_context_lines = 3;
             if (i + 1 < argc && argv[i + 1][0] != '-') {
-                if (parse_nonnegative_size_value(argv[++i],
-                                                 "hunk context",
-                                                 SIZE_MAX,
-                                                 &options->hunk_context_lines) != 0) {
+                if (parse_size_value(argv[++i],
+                                     "hunk context",
+                                     0,
+                                     SIZE_MAX,
+                                     &options->hunk_context_lines) != 0) {
                     return -1;
                 }
             }
         } else if (strncmp(argv[i], "--hunks=", 8) == 0) {
             options->show_hunks = 1;
-            if (parse_nonnegative_size_value(argv[i] + 8,
-                                             "hunk context",
-                                             SIZE_MAX,
-                                             &options->hunk_context_lines) != 0) {
+            if (parse_size_value(argv[i] + 8,
+                                 "hunk context",
+                                 0,
+                                 SIZE_MAX,
+                                 &options->hunk_context_lines) != 0) {
                 return -1;
             }
         } else if (strcmp(argv[i], "--tree-depth") == 0) {
             if (i + 1 < argc) {
-                if (parse_positive_size_value(argv[++i], "tree depth", SIZE_MAX, &options->tree_depth) != 0) {
+                if (parse_size_value(argv[++i], "tree depth", 1, SIZE_MAX, &options->tree_depth) != 0) {
                     return -1;
                 }
             } else {
@@ -223,12 +201,12 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
                 return -1;
             }
         } else if (strncmp(argv[i], "--tree-depth=", 13) == 0) {
-            if (parse_positive_size_value(argv[i] + 13, "tree depth", SIZE_MAX, &options->tree_depth) != 0) {
+            if (parse_size_value(argv[i] + 13, "tree depth", 1, SIZE_MAX, &options->tree_depth) != 0) {
                 return -1;
             }
         } else if (strcmp(argv[i], "--warn-tokens") == 0) {
             if (i + 1 < argc) {
-                if (parse_positive_size_value(argv[++i], "warn-tokens", SIZE_MAX, &options->warn_tokens) != 0) {
+                if (parse_size_value(argv[++i], "warn-tokens", 1, SIZE_MAX, &options->warn_tokens) != 0) {
                     return -1;
                 }
             } else {
@@ -237,12 +215,12 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
                 return -1;
             }
         } else if (strncmp(argv[i], "--warn-tokens=", 14) == 0) {
-            if (parse_positive_size_value(argv[i] + 14, "warn-tokens", SIZE_MAX, &options->warn_tokens) != 0) {
+            if (parse_size_value(argv[i] + 14, "warn-tokens", 1, SIZE_MAX, &options->warn_tokens) != 0) {
                 return -1;
             }
         } else if (strcmp(argv[i], "--max-tokens") == 0) {
             if (i + 1 < argc) {
-                if (parse_positive_size_value(argv[++i], "max-tokens", SIZE_MAX, &options->max_tokens) != 0) {
+                if (parse_size_value(argv[++i], "max-tokens", 1, SIZE_MAX, &options->max_tokens) != 0) {
                     return -1;
                 }
             } else {
@@ -251,7 +229,7 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options) {
                 return -1;
             }
         } else if (strncmp(argv[i], "--max-tokens=", 13) == 0) {
-            if (parse_positive_size_value(argv[i] + 13, "max-tokens", SIZE_MAX, &options->max_tokens) != 0) {
+            if (parse_size_value(argv[i] + 13, "max-tokens", 1, SIZE_MAX, &options->max_tokens) != 0) {
                 return -1;
             }
         } else if (strcmp(argv[i], "--staged") == 0) {

--- a/src/render.c
+++ b/src/render.c
@@ -771,13 +771,8 @@ static int emit_entry(RenderSink* sink,
     }
 }
 
-int prepare_render_plan(const ExportPlan* plan,
-                        const ExportRenderContext* ctx,
-                        RenderPlanInfo* info) {
-    GitFileHunks* hunks = NULL;
-    size_t hunk_count = 0;
-
-    if (!plan || !ctx || !info) {
+static int initialize_render_plan_info(const ExportPlan* plan, RenderPlanInfo* info) {
+    if (!plan || !info) {
         errno = EINVAL;
         return -1;
     }
@@ -802,63 +797,132 @@ int prepare_render_plan(const ExportPlan* plan,
         info->include_mask[i] = 1;
     }
 
-    if (!ctx->show_hunks) {
-        info->visible_count = plan->count;
-        return 0;
+    return 0;
+}
+
+static int collect_render_hunks(const ExportPlan* plan,
+                                const ExportRenderContext* ctx,
+                                GitFileHunks** hunks_out,
+                                size_t* hunk_count_out) {
+    if (!plan || !ctx || !hunks_out || !hunk_count_out) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (ctx->selected_count != plan->count) {
+        errno = EINVAL;
+        return -1;
     }
 
-    if (ctx->selected_count != plan->count ||
-        collect_git_hunks(ctx->mode,
+    if (collect_git_hunks(ctx->mode,
                           ctx->diff_range,
                           ctx->selected_paths,
                           ctx->selected_count,
-                          &hunks,
-                          &hunk_count) != 0 ||
-        hunk_count != plan->count) {
-        free_git_hunks(hunks, hunk_count);
-        free_render_plan_info(info);
+                          hunks_out,
+                          hunk_count_out) != 0) {
+        return -1;
+    }
+    if (*hunk_count_out != plan->count) {
+        free_git_hunks(*hunks_out, *hunk_count_out);
+        *hunks_out = NULL;
+        *hunk_count_out = 0;
+        errno = EINVAL;
+        return -1;
+    }
+
+    return 0;
+}
+
+static int prepare_hunk_render_entry(const ExportEntry* entry,
+                                     const SelectedPath* path,
+                                     const GitFileHunks* file_hunks,
+                                     size_t context_lines,
+                                     RenderEntryInfo* entry_info,
+                                     unsigned char* include_mask,
+                                     size_t* visible_count) {
+    if (!entry || !path || !file_hunks || !entry_info || !include_mask || !visible_count) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (strcmp(entry->open_path, path->open_path) != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (path->change_type == SELECTED_PATH_CHANGE_ADDED) {
+        entry_info->mode = RENDER_ENTRY_FULL;
+        *include_mask = 1;
+        (*visible_count)++;
+        return 0;
+    }
+
+    if (compute_entry_render_ranges(entry, file_hunks, context_lines, entry_info) != 0) {
+        return -1;
+    }
+
+    if (entry_info->range_count > 0) {
+        entry_info->mode = RENDER_ENTRY_SLICED;
+        *include_mask = 1;
+        (*visible_count)++;
+    } else {
+        entry_info->mode = RENDER_ENTRY_OMIT;
+        *include_mask = 0;
+    }
+
+    return 0;
+}
+
+static int prepare_hunk_render_plan(const ExportPlan* plan,
+                                    const ExportRenderContext* ctx,
+                                    RenderPlanInfo* info) {
+    GitFileHunks* hunks = NULL;
+    size_t hunk_count = 0;
+    int status = -1;
+
+    if (collect_render_hunks(plan, ctx, &hunks, &hunk_count) != 0) {
         return -1;
     }
 
     info->visible_count = 0;
     for (size_t i = 0; i < plan->count; i++) {
-        RenderEntryInfo* entry_info = &info->entries[i];
-        const SelectedPath* path = &ctx->selected_paths[i];
-
-        if (strcmp(plan->entries[i].open_path, path->open_path) != 0) {
-            free_git_hunks(hunks, hunk_count);
-            free_render_plan_info(info);
-            errno = EINVAL;
-            return -1;
-        }
-
-        if (path->change_type == SELECTED_PATH_CHANGE_ADDED) {
-            entry_info->mode = RENDER_ENTRY_FULL;
-            info->include_mask[i] = 1;
-            info->visible_count++;
-            continue;
-        }
-
-        if (compute_entry_render_ranges(&plan->entries[i],
-                                        &hunks[i],
-                                        ctx->hunk_context_lines,
-                                        entry_info) != 0) {
-            free_git_hunks(hunks, hunk_count);
-            free_render_plan_info(info);
-            return -1;
-        }
-
-        if (entry_info->range_count > 0) {
-            entry_info->mode = RENDER_ENTRY_SLICED;
-            info->include_mask[i] = 1;
-            info->visible_count++;
-        } else {
-            entry_info->mode = RENDER_ENTRY_OMIT;
-            info->include_mask[i] = 0;
+        if (prepare_hunk_render_entry(&plan->entries[i],
+                                      &ctx->selected_paths[i],
+                                      &hunks[i],
+                                      ctx->hunk_context_lines,
+                                      &info->entries[i],
+                                      &info->include_mask[i],
+                                      &info->visible_count) != 0) {
+            goto cleanup;
         }
     }
 
+    status = 0;
+
+cleanup:
     free_git_hunks(hunks, hunk_count);
+    return status;
+}
+
+int prepare_render_plan(const ExportPlan* plan,
+                        const ExportRenderContext* ctx,
+                        RenderPlanInfo* info) {
+    if (!plan || !ctx || !info) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (initialize_render_plan_info(plan, info) != 0) {
+        return -1;
+    }
+
+    if (!ctx->show_hunks) {
+        info->visible_count = plan->count;
+        return 0;
+    }
+
+    if (prepare_hunk_render_plan(plan, ctx, info) != 0) {
+        free_render_plan_info(info);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/sensitive.c
+++ b/src/sensitive.c
@@ -1,0 +1,187 @@
+#include "sensitive.h"
+
+#include <ctype.h>
+#include <string.h>
+
+static int equals_ignore_case_char(unsigned char lhs, unsigned char rhs) {
+    return tolower(lhs) == tolower(rhs);
+}
+
+static int starts_with_ignore_case(const char* text, const char* prefix) {
+    if (!text || !prefix) return 0;
+    while (*prefix != '\0') {
+        if (*text == '\0' || !equals_ignore_case_char((unsigned char)*text, (unsigned char)*prefix)) {
+            return 0;
+        }
+        text++;
+        prefix++;
+    }
+    return 1;
+}
+
+static int equals_ignore_case(const char* lhs, const char* rhs) {
+    if (!lhs || !rhs) return 0;
+    while (*lhs != '\0' && *rhs != '\0') {
+        if (!equals_ignore_case_char((unsigned char)*lhs, (unsigned char)*rhs)) {
+            return 0;
+        }
+        lhs++;
+        rhs++;
+    }
+    return *lhs == '\0' && *rhs == '\0';
+}
+
+static int ends_with_ignore_case(const char* text, const char* suffix) {
+    size_t text_len;
+    size_t suffix_len;
+
+    if (!text || !suffix) return 0;
+    text_len = strlen(text);
+    suffix_len = strlen(suffix);
+    if (suffix_len > text_len) return 0;
+    return equals_ignore_case(text + text_len - suffix_len, suffix);
+}
+
+static int is_sensitive_basename_prefix(const char* basename, const char* prefix) {
+    if (!basename || !prefix) return 0;
+    return starts_with_ignore_case(basename, prefix);
+}
+
+int fuori_is_sensitive_filename(const char* filepath) {
+    const char* basename = filepath;
+    const char* slash = strrchr(filepath, '/');
+
+    if (!filepath) {
+        return 0;
+    }
+    if (slash) {
+        basename = slash + 1;
+    }
+
+    if (is_sensitive_basename_prefix(basename, ".env") ||
+        is_sensitive_basename_prefix(basename, "credential") ||
+        is_sensitive_basename_prefix(basename, "credentials") ||
+        is_sensitive_basename_prefix(basename, "secret") ||
+        is_sensitive_basename_prefix(basename, "secrets") ||
+        is_sensitive_basename_prefix(basename, "id_rsa") ||
+        is_sensitive_basename_prefix(basename, "id_dsa") ||
+        is_sensitive_basename_prefix(basename, "id_ecdsa") ||
+        is_sensitive_basename_prefix(basename, "id_ed25519") ||
+        ends_with_ignore_case(basename, ".pem") ||
+        ends_with_ignore_case(basename, ".key")) {
+        return 1;
+    }
+
+    return 0;
+}
+
+static int buffer_contains_literal(const unsigned char* buffer,
+                                   size_t bytes_read,
+                                   const char* needle) {
+    size_t needle_len;
+
+    if (!buffer || !needle) {
+        return 0;
+    }
+    needle_len = strlen(needle);
+    if (needle_len == 0 || needle_len > bytes_read) {
+        return 0;
+    }
+
+    for (size_t i = 0; i + needle_len <= bytes_read; i++) {
+        if (memcmp(buffer + i, needle, needle_len) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int is_upper_alnum(unsigned char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+}
+
+static int is_openai_key_char(unsigned char c) {
+    return (c >= 'A' && c <= 'Z') ||
+           (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') ||
+           c == '-' ||
+           c == '_';
+}
+
+static int buffer_contains_prefixed_run(const unsigned char* buffer,
+                                        size_t bytes_read,
+                                        const char* prefix,
+                                        size_t required_run_len,
+                                        int (*char_ok)(unsigned char)) {
+    size_t prefix_len;
+
+    if (!buffer || !prefix || !char_ok) {
+        return 0;
+    }
+    prefix_len = strlen(prefix);
+    if (prefix_len == 0 || prefix_len + required_run_len > bytes_read) {
+        return 0;
+    }
+
+    for (size_t i = 0; i + prefix_len + required_run_len <= bytes_read; i++) {
+        size_t run_len = 0;
+
+        if (memcmp(buffer + i, prefix, prefix_len) != 0) {
+            continue;
+        }
+        while (i + prefix_len + run_len < bytes_read &&
+               char_ok(buffer[i + prefix_len + run_len])) {
+            run_len++;
+        }
+        if (run_len >= required_run_len) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int fuori_contains_sensitive_content(const unsigned char* buffer, size_t bytes_read) {
+    static const char* private_key_markers[] = {
+        "-----BEGIN PRIVATE KEY-----",
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "-----BEGIN OPENSSH PRIVATE KEY-----",
+        "-----BEGIN EC PRIVATE KEY-----",
+        "-----BEGIN DSA PRIVATE KEY-----",
+        "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+        NULL
+    };
+    static const char* github_prefixes[] = {
+        "ghp_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        NULL
+    };
+
+    if (!buffer) {
+        return 0;
+    }
+
+    for (size_t i = 0; private_key_markers[i] != NULL; i++) {
+        if (buffer_contains_literal(buffer, bytes_read, private_key_markers[i])) {
+            return 1;
+        }
+    }
+    if (buffer_contains_prefixed_run(buffer, bytes_read, "AKIA", 16, is_upper_alnum) ||
+        buffer_contains_prefixed_run(buffer, bytes_read, "ASIA", 16, is_upper_alnum)) {
+        return 1;
+    }
+    for (size_t i = 0; github_prefixes[i] != NULL; i++) {
+        if (buffer_contains_prefixed_run(buffer, bytes_read, github_prefixes[i], 20, is_openai_key_char)) {
+            return 1;
+        }
+    }
+    if (buffer_contains_prefixed_run(buffer, bytes_read, "sk-", 20, is_openai_key_char)) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/sensitive.h
+++ b/src/sensitive.h
@@ -1,0 +1,9 @@
+#ifndef SENSITIVE_H
+#define SENSITIVE_H
+
+#include <stddef.h>
+
+int fuori_is_sensitive_filename(const char* filepath);
+int fuori_contains_sensitive_content(const unsigned char* buffer, size_t bytes_read);
+
+#endif

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -538,6 +538,21 @@ if (cd "$REPO" && "$BIN" --staged --hunks=-1 >/dev/null 2>stderr_hunks_negative_
 fi
 assert_contains "$REPO/stderr_hunks_negative_invalid.txt" "Invalid hunk context value: -1"
 
+if (cd "$REPO" && "$BIN" --tree-depth=-1 >/dev/null 2>stderr_tree_depth_negative_invalid.txt); then
+    fail "expected --tree-depth=-1 to fail"
+fi
+assert_contains "$REPO/stderr_tree_depth_negative_invalid.txt" "Invalid tree depth value: -1"
+
+if (cd "$REPO" && "$BIN" --warn-tokens=-1 >/dev/null 2>stderr_warn_tokens_negative_invalid.txt); then
+    fail "expected --warn-tokens=-1 to fail"
+fi
+assert_contains "$REPO/stderr_warn_tokens_negative_invalid.txt" "Invalid warn-tokens value: -1"
+
+if (cd "$REPO" && "$BIN" --max-tokens=-1 >/dev/null 2>stderr_max_tokens_negative_invalid.txt); then
+    fail "expected --max-tokens=-1 to fail"
+fi
+assert_contains "$REPO/stderr_max_tokens_negative_invalid.txt" "Invalid max-tokens value: -1"
+
 STAGED_REPO="$TMPDIR/staged_repo"
 mkdir -p "$STAGED_REPO"
 (cd "$STAGED_REPO" && git init -q)


### PR DESCRIPTION
## Summary
Refactor three growing areas of the codebase to keep `fuori` maintainable without changing its behavior.

## Changes
- Unify numeric option parsing in `options.c` behind a single size-value parser with configurable minimums
- Move sensitive filename/content screening out of `collect.c` into a dedicated `sensitive.c` / `sensitive.h` module
- Split render-plan preparation into smaller helpers so hunk-aware rendering logic is easier to follow and maintain
- Update the build to compile the new sensitive-screening module
- Keep existing CLI behavior and regression coverage intact

## Why
These changes reduce duplication, clarify ownership boundaries, and make the most complex code paths easier to reason about:
- option parsing no longer has two near-duplicate integer parsers
- file collection no longer mixes filesystem walking with secret-detection details
- render prep no longer concentrates all hunk classification and range-building logic in one large function

## Verification
- Ran `make test` successfully
- Manual auditing of some output samples