### PR TITLE
fix resolved mode validation and narrow secret detection

### DIFF
--- a/src/collect.c
+++ b/src/collect.c
@@ -277,6 +277,12 @@ static int read_file_buffer(const char* filepath,
                             size_t max_file_size,
                             unsigned char** buffer_out,
                             size_t* bytes_read_out) {
+    enum {
+        READ_FILE_ERROR = -1,
+        READ_FILE_OK = 0,
+        READ_FILE_TOO_LARGE = 1,
+        READ_FILE_CHANGED = 2
+    };
     int fd = -1;
     FILE* file = NULL;
     unsigned char* buffer = NULL;
@@ -293,7 +299,7 @@ static int read_file_buffer(const char* filepath,
     if (st->st_size < 0) {
         errno = EINVAL;
         perror("Invalid file size");
-        return -1;
+        return READ_FILE_ERROR;
     }
 
     int open_flags = O_RDONLY;
@@ -303,41 +309,39 @@ static int read_file_buffer(const char* filepath,
     fd = open(filepath, open_flags);
     if (fd == -1) {
         perror("Error opening file");
-        return -1;
+        return READ_FILE_ERROR;
     }
     if (fstat(fd, &opened_st) == -1) {
         close(fd);
         perror("Error stating opened file");
-        return -1;
+        return READ_FILE_ERROR;
     }
     if (!S_ISREG(opened_st.st_mode)) {
         close(fd);
         errno = EINVAL;
         perror("Opened path is not a regular file");
-        return -1;
+        return READ_FILE_ERROR;
     }
     if (opened_st.st_dev != st->st_dev || opened_st.st_ino != st->st_ino) {
         close(fd);
-        errno = EAGAIN;
-        perror("File changed while being processed");
-        return -1;
+        return READ_FILE_CHANGED;
     }
     if (opened_st.st_size < 0) {
         close(fd);
         errno = EINVAL;
         perror("Invalid opened file size");
-        return -1;
+        return READ_FILE_ERROR;
     }
     if ((size_t)opened_st.st_size > max_file_size) {
         close(fd);
-        return 1;
+        return READ_FILE_TOO_LARGE;
     }
 
     file = fdopen(fd, "rb");
     if (!file) {
         close(fd);
         perror("Error converting file descriptor to stream");
-        return -1;
+        return READ_FILE_ERROR;
     }
     fd = -1;
 
@@ -347,16 +351,19 @@ static int read_file_buffer(const char* filepath,
     if (!buffer) {
         fclose(file);
         perror("Error allocating memory");
-        return -1;
+        return READ_FILE_ERROR;
     }
 
     if (buffer_size > 0) {
         bytes_read = fread(buffer, 1, buffer_size, file);
-        if (bytes_read < buffer_size && ferror(file)) {
+        if (bytes_read < buffer_size) {
             free(buffer);
             fclose(file);
-            perror("Error reading file");
-            return -1;
+            if (ferror(file)) {
+                perror("Error reading file");
+                return READ_FILE_ERROR;
+            }
+            return READ_FILE_CHANGED;
         }
     }
 
@@ -366,13 +373,13 @@ static int read_file_buffer(const char* filepath,
             fclose(file);
             errno = EOVERFLOW;
             perror("File too large");
-            return -1;
+            return READ_FILE_ERROR;
         }
         size_t needed = bytes_read + extra_read;
         if (needed > max_file_size) {
             free(buffer);
             fclose(file);
-            return 1;
+            return READ_FILE_TOO_LARGE;
         }
         if (needed > buffer_capacity) {
             size_t new_capacity = buffer_capacity;
@@ -389,7 +396,7 @@ static int read_file_buffer(const char* filepath,
                 free(buffer);
                 fclose(file);
                 perror("Error growing file buffer");
-                return -1;
+                return READ_FILE_ERROR;
             }
             buffer = new_buffer;
             buffer_capacity = new_capacity;
@@ -401,17 +408,17 @@ static int read_file_buffer(const char* filepath,
         free(buffer);
         fclose(file);
         perror("Error reading file");
-        return -1;
+        return READ_FILE_ERROR;
     }
     if (fclose(file) != 0) {
         free(buffer);
         perror("Error closing file");
-        return -1;
+        return READ_FILE_ERROR;
     }
 
     *buffer_out = buffer;
     *bytes_read_out = bytes_read;
-    return 0;
+    return READ_FILE_OK;
 }
 
 static int append_export_entry(ExportPlan* plan,
@@ -523,6 +530,10 @@ static int collect_exportable_file(const char* open_path,
         if (ctx->verbose) {
             fprintf(stderr, "Skipping oversized file: %s\n", display_path);
         }
+        return 0;
+    }
+    if (read_result == 2) {
+        fprintf(stderr, "Warning: File changed while being processed %s\n", display_path);
         return 0;
     }
     if (read_result != 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -270,6 +270,9 @@ int main(int argc, char* argv[]) {
     if (resolve_cli_selection(&options, &selected_paths, &selected_count) != 0) {
         goto cleanup;
     }
+    if (validate_resolved_cli_options(&options) != 0) {
+        goto cleanup;
+    }
 
     ctx.verbose = options.verbose;
     ctx.no_clobber = options.no_clobber;

--- a/src/options.c
+++ b/src/options.c
@@ -363,3 +363,18 @@ int resolve_cli_selection(CliOptions* options,
                              selected_count_out,
                              &git_result);
 }
+
+int validate_resolved_cli_options(const CliOptions* options) {
+    if (!options) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (options->no_default_ignore &&
+        options->resolved_mode != FILE_SELECTION_RECURSIVE) {
+        print_no_default_ignore_conflict();
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/options.h
+++ b/src/options.h
@@ -33,5 +33,6 @@ int parse_cli_options(int argc, char* argv[], CliOptions* options);
 int resolve_cli_selection(CliOptions* options,
                           SelectedPath** selected_paths_out,
                           size_t* selected_count_out);
+int validate_resolved_cli_options(const CliOptions* options);
 
 #endif

--- a/src/sensitive.c
+++ b/src/sensitive.c
@@ -3,6 +3,32 @@
 #include <ctype.h>
 #include <string.h>
 
+typedef enum {
+    SENSITIVE_MATCH_HARD = 0,
+    SENSITIVE_MATCH_SOFT
+} SensitiveMatchSeverity;
+
+typedef enum {
+    TOKEN_CONTEXT_NONE = 0,
+    TOKEN_CONTEXT_ASSIGNMENT_OR_BEARER
+} SensitiveTokenContext;
+
+typedef struct {
+    const char* begin_marker;
+    const char* end_marker;
+    SensitiveMatchSeverity severity;
+} SensitiveLiteralRule;
+
+typedef struct {
+    const char* prefix;
+    size_t min_run_len;
+    size_t max_run_len;
+    int (*char_ok)(unsigned char);
+    int require_boundaries;
+    SensitiveTokenContext context_requirement;
+    SensitiveMatchSeverity severity;
+} SensitivePrefixRule;
+
 static int equals_ignore_case_char(unsigned char lhs, unsigned char rhs) {
     return tolower(lhs) == tolower(rhs);
 }
@@ -42,9 +68,17 @@ static int ends_with_ignore_case(const char* text, const char* suffix) {
     return equals_ignore_case(text + text_len - suffix_len, suffix);
 }
 
-static int is_sensitive_basename_prefix(const char* basename, const char* prefix) {
-    if (!basename || !prefix) return 0;
-    return starts_with_ignore_case(basename, prefix);
+static int matches_sensitive_basename_pattern(const char* basename, const char* stem) {
+    size_t stem_len;
+
+    if (!basename || !stem) {
+        return 0;
+    }
+    stem_len = strlen(stem);
+    if (!starts_with_ignore_case(basename, stem)) {
+        return 0;
+    }
+    return basename[stem_len] == '\0' || basename[stem_len] == '.';
 }
 
 int fuori_is_sensitive_filename(const char* filepath) {
@@ -58,15 +92,15 @@ int fuori_is_sensitive_filename(const char* filepath) {
         basename = slash + 1;
     }
 
-    if (is_sensitive_basename_prefix(basename, ".env") ||
-        is_sensitive_basename_prefix(basename, "credential") ||
-        is_sensitive_basename_prefix(basename, "credentials") ||
-        is_sensitive_basename_prefix(basename, "secret") ||
-        is_sensitive_basename_prefix(basename, "secrets") ||
-        is_sensitive_basename_prefix(basename, "id_rsa") ||
-        is_sensitive_basename_prefix(basename, "id_dsa") ||
-        is_sensitive_basename_prefix(basename, "id_ecdsa") ||
-        is_sensitive_basename_prefix(basename, "id_ed25519") ||
+    if (matches_sensitive_basename_pattern(basename, ".env") ||
+        matches_sensitive_basename_pattern(basename, "credential") ||
+        matches_sensitive_basename_pattern(basename, "credentials") ||
+        matches_sensitive_basename_pattern(basename, "secret") ||
+        matches_sensitive_basename_pattern(basename, "secrets") ||
+        equals_ignore_case(basename, "id_rsa") ||
+        equals_ignore_case(basename, "id_dsa") ||
+        equals_ignore_case(basename, "id_ecdsa") ||
+        equals_ignore_case(basename, "id_ed25519") ||
         ends_with_ignore_case(basename, ".pem") ||
         ends_with_ignore_case(basename, ".key")) {
         return 1;
@@ -75,22 +109,32 @@ int fuori_is_sensitive_filename(const char* filepath) {
     return 0;
 }
 
-static int buffer_contains_literal(const unsigned char* buffer,
-                                   size_t bytes_read,
-                                   const char* needle) {
-    size_t needle_len;
+static int buffer_contains_literal_pair(const unsigned char* buffer,
+                                        size_t bytes_read,
+                                        const char* begin_marker,
+                                        const char* end_marker) {
+    size_t begin_len;
+    size_t end_len;
 
-    if (!buffer || !needle) {
-        return 0;
-    }
-    needle_len = strlen(needle);
-    if (needle_len == 0 || needle_len > bytes_read) {
+    if (!buffer || !begin_marker || !end_marker) {
         return 0;
     }
 
-    for (size_t i = 0; i + needle_len <= bytes_read; i++) {
-        if (memcmp(buffer + i, needle, needle_len) == 0) {
-            return 1;
+    begin_len = strlen(begin_marker);
+    end_len = strlen(end_marker);
+    if (begin_len == 0 || end_len == 0 ||
+        begin_len > bytes_read || end_len > bytes_read) {
+        return 0;
+    }
+
+    for (size_t i = 0; i + begin_len <= bytes_read; i++) {
+        if (memcmp(buffer + i, begin_marker, begin_len) != 0) {
+            continue;
+        }
+        for (size_t j = i + begin_len; j + end_len <= bytes_read; j++) {
+            if (memcmp(buffer + j, end_marker, end_len) == 0) {
+                return 1;
+            }
         }
     }
 
@@ -109,32 +153,98 @@ static int is_openai_key_char(unsigned char c) {
            c == '_';
 }
 
-static int buffer_contains_prefixed_run(const unsigned char* buffer,
-                                        size_t bytes_read,
-                                        const char* prefix,
-                                        size_t required_run_len,
-                                        int (*char_ok)(unsigned char)) {
+static int has_run_boundary_before(const unsigned char* buffer,
+                                   size_t match_start,
+                                   int (*char_ok)(unsigned char)) {
+    if (match_start == 0) {
+        return 1;
+    }
+    return !char_ok(buffer[match_start - 1]);
+}
+
+static int has_run_boundary_after(const unsigned char* buffer,
+                                  size_t bytes_read,
+                                  size_t run_end,
+                                  int (*char_ok)(unsigned char)) {
+    if (run_end >= bytes_read) {
+        return 1;
+    }
+    return !char_ok(buffer[run_end]);
+}
+
+static int has_assignment_or_bearer_context(const unsigned char* buffer,
+                                            size_t bytes_read,
+                                            size_t match_start) {
+    size_t scan_start;
+
+    (void)bytes_read;
+
+    if (match_start >= 7 &&
+        memcmp(buffer + match_start - 7, "Bearer ", 7) == 0) {
+        return 1;
+    }
+
+    scan_start = (match_start > 32) ? (match_start - 32) : 0;
+    for (size_t i = match_start; i > scan_start; i--) {
+        unsigned char c = buffer[i - 1];
+        if (c == '=' || c == ':') {
+            return 1;
+        }
+        if (c == '\n' || c == '\r') {
+            break;
+        }
+    }
+
+    return 0;
+}
+
+static int buffer_contains_rule_match(const unsigned char* buffer,
+                                      size_t bytes_read,
+                                      const SensitivePrefixRule* rule) {
     size_t prefix_len;
 
-    if (!buffer || !prefix || !char_ok) {
+    if (!buffer || !rule || !rule->prefix || !rule->char_ok) {
         return 0;
     }
-    prefix_len = strlen(prefix);
-    if (prefix_len == 0 || prefix_len + required_run_len > bytes_read) {
+    prefix_len = strlen(rule->prefix);
+    if (prefix_len == 0 || prefix_len + rule->min_run_len > bytes_read) {
         return 0;
     }
 
-    for (size_t i = 0; i + prefix_len + required_run_len <= bytes_read; i++) {
+    for (size_t i = 0; i + prefix_len + rule->min_run_len <= bytes_read; i++) {
         size_t run_len = 0;
 
-        if (memcmp(buffer + i, prefix, prefix_len) != 0) {
+        if (memcmp(buffer + i, rule->prefix, prefix_len) != 0) {
             continue;
         }
+        if (rule->require_boundaries &&
+            !has_run_boundary_before(buffer, i, rule->char_ok)) {
+            continue;
+        }
+
         while (i + prefix_len + run_len < bytes_read &&
-               char_ok(buffer[i + prefix_len + run_len])) {
+               rule->char_ok(buffer[i + prefix_len + run_len]) &&
+               run_len < rule->max_run_len) {
             run_len++;
         }
-        if (run_len >= required_run_len) {
+
+        if (run_len < rule->min_run_len) {
+            continue;
+        }
+        if (rule->require_boundaries &&
+            !has_run_boundary_after(buffer,
+                                    bytes_read,
+                                    i + prefix_len + run_len,
+                                    rule->char_ok)) {
+            continue;
+        }
+        if (rule->context_requirement == TOKEN_CONTEXT_ASSIGNMENT_OR_BEARER &&
+            !has_assignment_or_bearer_context(buffer, bytes_read, i)) {
+            continue;
+        }
+
+        if (rule->severity == SENSITIVE_MATCH_HARD ||
+            rule->severity == SENSITIVE_MATCH_SOFT) {
             return 1;
         }
     }
@@ -143,44 +253,45 @@ static int buffer_contains_prefixed_run(const unsigned char* buffer,
 }
 
 int fuori_contains_sensitive_content(const unsigned char* buffer, size_t bytes_read) {
-    static const char* private_key_markers[] = {
-        "-----BEGIN PRIVATE KEY-----",
-        "-----BEGIN RSA PRIVATE KEY-----",
-        "-----BEGIN OPENSSH PRIVATE KEY-----",
-        "-----BEGIN EC PRIVATE KEY-----",
-        "-----BEGIN DSA PRIVATE KEY-----",
-        "-----BEGIN PGP PRIVATE KEY BLOCK-----",
-        NULL
+    static const SensitiveLiteralRule private_key_rules[] = {
+        {"-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----", SENSITIVE_MATCH_HARD},
+        {"-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----", SENSITIVE_MATCH_HARD},
+        {"-----BEGIN OPENSSH PRIVATE KEY-----", "-----END OPENSSH PRIVATE KEY-----", SENSITIVE_MATCH_HARD},
+        {"-----BEGIN EC PRIVATE KEY-----", "-----END EC PRIVATE KEY-----", SENSITIVE_MATCH_HARD},
+        {"-----BEGIN DSA PRIVATE KEY-----", "-----END DSA PRIVATE KEY-----", SENSITIVE_MATCH_HARD},
+        {"-----BEGIN PGP PRIVATE KEY BLOCK-----", "-----END PGP PRIVATE KEY BLOCK-----", SENSITIVE_MATCH_HARD},
+        {NULL, NULL, SENSITIVE_MATCH_HARD}
     };
-    static const char* github_prefixes[] = {
-        "ghp_",
-        "gho_",
-        "ghu_",
-        "ghs_",
-        "ghr_",
-        NULL
+    static const SensitivePrefixRule prefix_rules[] = {
+        {"AKIA", 16, 16, is_upper_alnum, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_HARD},
+        {"ASIA", 16, 16, is_upper_alnum, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_HARD},
+        {"ghp_", 30, 255, is_openai_key_char, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_SOFT},
+        {"gho_", 30, 255, is_openai_key_char, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_SOFT},
+        {"ghu_", 30, 255, is_openai_key_char, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_SOFT},
+        {"ghs_", 30, 255, is_openai_key_char, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_SOFT},
+        {"ghr_", 30, 255, is_openai_key_char, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_SOFT},
+        {"sk-", 40, 255, is_openai_key_char, 1, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_SOFT},
+        {NULL, 0, 0, NULL, 0, TOKEN_CONTEXT_NONE, SENSITIVE_MATCH_SOFT}
     };
 
     if (!buffer) {
         return 0;
     }
 
-    for (size_t i = 0; private_key_markers[i] != NULL; i++) {
-        if (buffer_contains_literal(buffer, bytes_read, private_key_markers[i])) {
+    for (size_t i = 0; private_key_rules[i].begin_marker != NULL; i++) {
+        if (buffer_contains_literal_pair(buffer,
+                                         bytes_read,
+                                         private_key_rules[i].begin_marker,
+                                         private_key_rules[i].end_marker) &&
+            (private_key_rules[i].severity == SENSITIVE_MATCH_HARD ||
+             private_key_rules[i].severity == SENSITIVE_MATCH_SOFT)) {
             return 1;
         }
     }
-    if (buffer_contains_prefixed_run(buffer, bytes_read, "AKIA", 16, is_upper_alnum) ||
-        buffer_contains_prefixed_run(buffer, bytes_read, "ASIA", 16, is_upper_alnum)) {
-        return 1;
-    }
-    for (size_t i = 0; github_prefixes[i] != NULL; i++) {
-        if (buffer_contains_prefixed_run(buffer, bytes_read, github_prefixes[i], 20, is_openai_key_char)) {
+    for (size_t i = 0; prefix_rules[i].prefix != NULL; i++) {
+        if (buffer_contains_rule_match(buffer, bytes_read, &prefix_rules[i])) {
             return 1;
         }
-    }
-    if (buffer_contains_prefixed_run(buffer, bytes_read, "sk-", 20, is_openai_key_char)) {
-        return 1;
     }
 
     return 0;

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -143,37 +143,68 @@ EOF_SENSITIVE_NAME_MAIN
 cat >"$SENSITIVE_NAME_DIR/credentials.txt" <<'EOF_SENSITIVE_NAME_SECRET'
 plain text but sensitive by filename
 EOF_SENSITIVE_NAME_SECRET
+cat >"$SENSITIVE_NAME_DIR/credential.txt" <<'EOF_SENSITIVE_NAME_CREDENTIAL'
+plain text but sensitive by exact singular filename
+EOF_SENSITIVE_NAME_CREDENTIAL
+cat >"$SENSITIVE_NAME_DIR/.env.local" <<'EOF_SENSITIVE_NAME_ENV'
+export TOKEN=1
+EOF_SENSITIVE_NAME_ENV
+cat >"$SENSITIVE_NAME_DIR/secret.txt" <<'EOF_SENSITIVE_NAME_SECRET_FILE'
+backup secret
+EOF_SENSITIVE_NAME_SECRET_FILE
+cat >"$SENSITIVE_NAME_DIR/secrets.json" <<'EOF_SENSITIVE_NAME_SECRETS_FILE'
+several secrets
+EOF_SENSITIVE_NAME_SECRETS_FILE
+cat >"$SENSITIVE_NAME_DIR/id_dsa" <<'EOF_SENSITIVE_NAME_ID_DSA'
+backup ssh key
+EOF_SENSITIVE_NAME_ID_DSA
 cat >"$SENSITIVE_NAME_DIR/.envrc" <<'EOF_SENSITIVE_NAME_ENVRC'
 export TOKEN=1
 EOF_SENSITIVE_NAME_ENVRC
 cat >"$SENSITIVE_NAME_DIR/credentials-prod.txt" <<'EOF_SENSITIVE_NAME_CREDENTIALS_DASH'
 prod credentials
 EOF_SENSITIVE_NAME_CREDENTIALS_DASH
-cat >"$SENSITIVE_NAME_DIR/secret_backup" <<'EOF_SENSITIVE_NAME_SECRET_BACKUP'
-backup secret
-EOF_SENSITIVE_NAME_SECRET_BACKUP
+cat >"$SENSITIVE_NAME_DIR/credentials-guide.md" <<'EOF_SENSITIVE_NAME_CREDENTIALS_GUIDE'
+how to rotate credentials
+EOF_SENSITIVE_NAME_CREDENTIALS_GUIDE
+cat >"$SENSITIVE_NAME_DIR/secretary_notes.md" <<'EOF_SENSITIVE_NAME_SECRETARY'
+meeting notes
+EOF_SENSITIVE_NAME_SECRETARY
 cat >"$SENSITIVE_NAME_DIR/id_rsa_backup" <<'EOF_SENSITIVE_NAME_ID_RSA_BACKUP'
 backup ssh key
 EOF_SENSITIVE_NAME_ID_RSA_BACKUP
 (cd "$SENSITIVE_NAME_DIR" && "$BIN" --no-git -o - >sensitive_name_stdout.txt 2>"$TMPDIR/sensitive_name_stderr.txt")
 assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## main.c"
 assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "credentials.txt"
-assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" ".envrc"
-assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "credentials-prod.txt"
-assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "secret_backup"
-assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "id_rsa_backup"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## credential.txt"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## .env.local"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## secret.txt"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## secrets.json"
+assert_not_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## id_dsa"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## .envrc"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## credentials-prod.txt"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## credentials-guide.md"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## secretary_notes.md"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_stdout.txt" "## id_rsa_backup"
 assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credentials.txt"
-assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./.envrc"
-assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credentials-prod.txt"
-assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./secret_backup"
-assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./id_rsa_backup"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credential.txt"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./.env.local"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./secret.txt"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./secrets.json"
+assert_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./id_dsa"
+assert_not_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./.envrc"
+assert_not_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credentials-prod.txt"
+assert_not_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./credentials-guide.md"
+assert_not_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./secretary_notes.md"
+assert_not_contains "$TMPDIR/sensitive_name_stderr.txt" "Warning: Skipping sensitive file ./id_rsa_backup"
 
 (cd "$SENSITIVE_NAME_DIR" && "$BIN" --no-git --allow-sensitive -o - >sensitive_name_allow_stdout.txt 2>"$TMPDIR/sensitive_name_allow_stderr.txt")
 assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## credentials.txt"
-assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## .envrc"
-assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## credentials-prod.txt"
-assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## secret_backup"
-assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## id_rsa_backup"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## credential.txt"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## .env.local"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## secret.txt"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## secrets.json"
+assert_contains "$SENSITIVE_NAME_DIR/sensitive_name_allow_stdout.txt" "## id_dsa"
 assert_not_contains "$TMPDIR/sensitive_name_allow_stderr.txt" "Warning: Skipping sensitive file"
 
 SENSITIVE_CONTENT_DIR="$TMPDIR/sensitive_content"
@@ -181,17 +212,34 @@ mkdir -p "$SENSITIVE_CONTENT_DIR"
 cat >"$SENSITIVE_CONTENT_DIR/main.c" <<'EOF_SENSITIVE_CONTENT_MAIN'
 int main(void) { return 0; }
 EOF_SENSITIVE_CONTENT_MAIN
-cat >"$SENSITIVE_CONTENT_DIR/notes.txt" <<'EOF_SENSITIVE_CONTENT_SECRET'
+cat >"$SENSITIVE_CONTENT_DIR/example.txt" <<'EOF_SENSITIVE_CONTENT_SHORT_TOKEN'
 api_key=sk-abcdefghijklmnopqrstuvwxyz123456
-EOF_SENSITIVE_CONTENT_SECRET
+EOF_SENSITIVE_CONTENT_SHORT_TOKEN
+cat >"$SENSITIVE_CONTENT_DIR/detector.c" <<'EOF_SENSITIVE_CONTENT_MARKER_LITERAL'
+const char* marker = "-----BEGIN PRIVATE KEY-----";
+EOF_SENSITIVE_CONTENT_MARKER_LITERAL
+cat >"$SENSITIVE_CONTENT_DIR/private_key.txt" <<'EOF_SENSITIVE_CONTENT_PEM'
+-----BEGIN PRIVATE KEY-----
+YWJjZGVmZw==
+-----END PRIVATE KEY-----
+EOF_SENSITIVE_CONTENT_PEM
+cat >"$SENSITIVE_CONTENT_DIR/openai.txt" <<'EOF_SENSITIVE_CONTENT_LONG_TOKEN'
+sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF_SENSITIVE_CONTENT_LONG_TOKEN
 (cd "$SENSITIVE_CONTENT_DIR" && "$BIN" --no-git -o - >sensitive_content_stdout.txt 2>"$TMPDIR/sensitive_content_stderr.txt")
 assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## main.c"
-assert_not_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## notes.txt"
-assert_contains "$TMPDIR/sensitive_content_stderr.txt" "Warning: Skipping sensitive file ./notes.txt"
-assert_not_contains "$TMPDIR/sensitive_content_stderr.txt" "sk-abcdefghijklmnopqrstuvwxyz123456"
+assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## example.txt"
+assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## detector.c"
+assert_not_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## private_key.txt"
+assert_not_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_stdout.txt" "## openai.txt"
+assert_contains "$TMPDIR/sensitive_content_stderr.txt" "Warning: Skipping sensitive file ./private_key.txt"
+assert_contains "$TMPDIR/sensitive_content_stderr.txt" "Warning: Skipping sensitive file ./openai.txt"
+assert_not_contains "$TMPDIR/sensitive_content_stderr.txt" "Warning: Skipping sensitive file ./example.txt"
+assert_not_contains "$TMPDIR/sensitive_content_stderr.txt" "Warning: Skipping sensitive file ./detector.c"
 
 (cd "$SENSITIVE_CONTENT_DIR" && "$BIN" --no-git --allow-sensitive -o - >sensitive_content_allow_stdout.txt 2>"$TMPDIR/sensitive_content_allow_stderr.txt")
-assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_allow_stdout.txt" "## notes.txt"
+assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_allow_stdout.txt" "## private_key.txt"
+assert_contains "$SENSITIVE_CONTENT_DIR/sensitive_content_allow_stdout.txt" "## openai.txt"
 assert_not_contains "$TMPDIR/sensitive_content_allow_stderr.txt" "Warning: Skipping sensitive file"
 
 (cd "$OUTSIDE" && "$BIN" -v -o verbose_export.md >verbose_file_stdout.txt 2>verbose_file_stderr.txt)
@@ -522,6 +570,11 @@ if (cd "$REPO" && "$BIN" --staged --no-default-ignore >/dev/null 2>stderr_no_def
     fail "expected --staged --no-default-ignore to fail"
 fi
 assert_contains "$REPO/stderr_no_default_ignore_invalid.txt" "--no-default-ignore can only be used with filesystem selection"
+
+if (cd "$REPO" && "$BIN" --no-default-ignore >/dev/null 2>stderr_no_default_ignore_auto_invalid.txt); then
+    fail "expected auto-mode --no-default-ignore in git repo to fail"
+fi
+assert_contains "$REPO/stderr_no_default_ignore_auto_invalid.txt" "--no-default-ignore can only be used with filesystem selection"
 
 if (cd "$REPO" && "$BIN" --hunks >/dev/null 2>stderr_hunks_default_invalid.txt); then
     fail "expected bare --hunks to fail"


### PR DESCRIPTION
## Summary

Fixes a few user-visible robustness issues in selection validation and sensitive-file filtering.

## What Changed

- Reject `--no-default-ignore` when auto mode resolves to Git-backed selection
- Keep that validation in the option-resolution layer instead of coercing modes in `main`
- Narrow filename-based sensitive detection from raw prefixes to explicit basename patterns
- Replace broad content token matching with per-rule checks for PEM blocks and token families
- Treat short reads as unstable file snapshots and skip them instead of exporting truncated content
- Add CLI regressions for the auto-mode validation bug and sensitive-detector true/false positives

## Why

Previously:
- `--no-default-ignore` was accepted in auto mode even when it resolved to Git worktree mode, where it had no effect
- the sensitive detector could suppress ordinary docs, tests, and source files with token-like content or filenames
- a file shrinking during read could be exported as a truncated snapshot

This change brings behavior back in line with the documented CLI contract and reduces false positives in default exports.

## Validation

- Ran `make test`
- All tests passed
- Manual auditing of output samples